### PR TITLE
fix bugs with large directory listing

### DIFF
--- a/example/helloworld/main.go
+++ b/example/helloworld/main.go
@@ -43,6 +43,6 @@ func main() {
 	_ = f.Close()
 
 	handler := nfshelper.NewNullAuthHandler(ROFS{mem})
-	cacheHelper := nfshelper.NewCachingHandler(handler)
+	cacheHelper := nfshelper.NewCachingHandler(handler, 1024)
 	fmt.Printf("%v", nfs.Serve(listener, cacheHelper))
 }

--- a/example/osnfs/main.go
+++ b/example/osnfs/main.go
@@ -30,6 +30,6 @@ func main() {
 	bfsPlusChange := NewChangeOSFS(bfs)
 
 	handler := nfshelper.NewNullAuthHandler(bfsPlusChange)
-	cacheHelper := nfshelper.NewCachingHandler(handler)
+	cacheHelper := nfshelper.NewCachingHandler(handler, 1024)
 	fmt.Printf("%v", nfs.Serve(listener, cacheHelper))
 }

--- a/example/osview/main.go
+++ b/example/osview/main.go
@@ -27,6 +27,6 @@ func main() {
 	bfs := fs.AsBillyFS(0, 0)
 
 	handler := nfshelper.NewNullAuthHandler(bfs)
-	cacheHelper := nfshelper.NewCachingHandler(handler)
+	cacheHelper := nfshelper.NewCachingHandler(handler, 1024)
 	fmt.Printf("%v", nfs.Serve(listener, cacheHelper))
 }

--- a/handler.go
+++ b/handler.go
@@ -25,4 +25,6 @@ type Handler interface {
 	// Can be safely implemented via helpers/cachinghandler.
 	ToHandle(fs billy.Filesystem, path []string) []byte
 	FromHandle(fh []byte) (billy.Filesystem, []string, error)
+	// How many handles can be safely maintained by the handler.
+	HandleLimit() int
 }

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -48,3 +48,8 @@ func (h *NullAuthHandler) ToHandle(f billy.Filesystem, s []string) []byte {
 func (h *NullAuthHandler) FromHandle([]byte) (billy.Filesystem, []string, error) {
 	return nil, []string{}, nil
 }
+
+// HandleLImit handled by cachingHandler
+func (h *NullAuthHandler) HandleLimit() int {
+	return -1
+}

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -71,7 +71,8 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 			maxBytes += 512 // TODO: better estimation.
 		} else if uint64(i) == obj.Cookie {
 			started = true
-		} else if maxBytes > obj.Count {
+		}
+		if started && (maxBytes > obj.Count || len(entities) > userHandle.HandleLimit()/2) {
 			started = false
 			entities = entities[0 : len(entities)-1]
 		}

--- a/nfs_onreaddirplus.go
+++ b/nfs_onreaddirplus.go
@@ -79,7 +79,8 @@ func onReadDirPlus(ctx context.Context, w *response, userHandle Handler) error {
 			maxBytes += 512 // TODO: better estimation.
 		} else if uint64(i) == obj.Cookie {
 			started = true
-		} else if dirBytes > obj.DirCount || maxBytes > obj.MaxCount {
+		}
+		if started && (dirBytes > obj.DirCount || maxBytes > obj.MaxCount || len(entities) > userHandle.HandleLimit()/2) {
 			started = false
 			entities = entities[0 : len(entities)-1]
 		}

--- a/nfs_test.go
+++ b/nfs_test.go
@@ -25,7 +25,7 @@ func TestNFS(t *testing.T) {
 	_, _ = mem.Create("/test")
 
 	handler := helpers.NewNullAuthHandler(mem)
-	cacheHelper := helpers.NewCachingHandler(handler)
+	cacheHelper := helpers.NewCachingHandler(handler, 1024)
 	go func() {
 		_ = nfs.Serve(listener, cacheHelper)
 	}()


### PR DESCRIPTION
* Allow maximum 'readdir' size based on the size of handle cache (so the directory won't become stale by reading it)
* fix issue with fragmentation calculation of 'readdir'
* fix #20 