### PR TITLE
add handler call on unmounts

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,8 @@ type Handler interface {
 
 	Mount(context.Context, net.Conn, MountRequest) (MountStatus, billy.Filesystem, []AuthFlavor)
 
+	Unmount(_ context.Context, _ net.Conn, dirpath []byte) error
+
 	// Change can return 'nil' if filesystem is read-only
 	Change(billy.Filesystem) billy.Change
 

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -26,6 +26,11 @@ func (h *NullAuthHandler) Mount(ctx context.Context, conn net.Conn, req nfs.Moun
 	return
 }
 
+// Unmount indicates the client connection has terminated.
+func (h *NullAuthHandler) Unmount(ctx context.Context, conn net.Conn, dirpath []byte) error {
+	return nil
+}
+
 // Change provides an interface for updating file attributes.
 func (h *NullAuthHandler) Change(fs billy.Filesystem) billy.Change {
 	if c, ok := h.fs.(billy.Change); ok {
@@ -49,7 +54,7 @@ func (h *NullAuthHandler) FromHandle([]byte) (billy.Filesystem, []string, error)
 	return nil, []string{}, nil
 }
 
-// HandleLImit handled by cachingHandler
+// HandleLimit is handled by cachingHandler
 func (h *NullAuthHandler) HandleLimit() int {
 	return -1
 }

--- a/mount.go
+++ b/mount.go
@@ -49,8 +49,12 @@ func onMount(ctx context.Context, w *response, userHandle Handler) error {
 }
 
 func onUMount(ctx context.Context, w *response, userHandle Handler) error {
-	_, err := xdr.ReadOpaque(w.req.Body)
+	dirpath, err := xdr.ReadOpaque(w.req.Body)
 	if err != nil {
+		return err
+	}
+
+	if err := userHandle.Unmount(ctx, w.conn, dirpath); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Allow handlers to correlate `Mount` and `Unmount` events to free resources like file handles when a client disconnects.