### PR TITLE
off-by-one issues with dir cookies

### DIFF
--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -49,6 +49,13 @@ func (c *CachingHandler) FromHandle(fh []byte) (billy.Filesystem, []string, erro
 
 	if cache, ok := c.activeHandles.Get(id); ok {
 		f, ok := cache.(entry)
+		for _, k := range c.activeHandles.Keys() {
+			e, _ := c.activeHandles.Peek(k)
+			candidate := e.(entry)
+			if hasPrefix(f.p, candidate.p) {
+				_, _ = c.activeHandles.Get(k)
+			}
+		}
 		if ok {
 			return f.f, f.p, nil
 		}
@@ -59,4 +66,16 @@ func (c *CachingHandler) FromHandle(fh []byte) (billy.Filesystem, []string, erro
 // HandleLimit exports how many file handles can be safely stored by this cache.
 func (c *CachingHandler) HandleLimit() int {
 	return c.cacheLimit
+}
+
+func hasPrefix(path, prefix []string) bool {
+	if len(prefix) > len(path) {
+		return false
+	}
+	for i, e := range prefix {
+		if path[i] != e {
+			return false
+		}
+	}
+	return true
 }

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -67,15 +67,16 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 	vHash := sha256.New()
 
 	for i, c := range contents {
+		actualI := i + 2
 		if started {
 			entities = append(entities, readDirEntity{
 				FileID: 1337, //todo: does this matter?
 				Name:   []byte(c.Name()),
-				Cookie: uint64(i + 3),
+				Cookie: uint64(actualI),
 				Next:   1,
 			})
 			maxBytes += 512 // TODO: better estimation.
-		} else if uint64(i) == obj.Cookie {
+		} else if uint64(actualI) == obj.Cookie {
 			started = true
 			everStarted = true
 		}
@@ -119,7 +120,7 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 		if err := xdr.Write(writer, []byte(".")); err != nil { // name
 			return &NFSStatusError{NFSStatusServerFault, err}
 		}
-		if err := xdr.Write(writer, uint64(1)); err != nil { // cookie
+		if err := xdr.Write(writer, uint64(0)); err != nil { // cookie
 			return &NFSStatusError{NFSStatusServerFault, err}
 		}
 		if err := xdr.Write(writer, uint32(1)); err != nil { // next
@@ -138,7 +139,7 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 		if err := xdr.Write(writer, []byte("..")); err != nil { //name
 			return &NFSStatusError{NFSStatusServerFault, err}
 		}
-		if err := xdr.Write(writer, uint64(2)); err != nil { // cookie
+		if err := xdr.Write(writer, uint64(1)); err != nil { // cookie
 			return &NFSStatusError{NFSStatusServerFault, err}
 		}
 	}


### PR DESCRIPTION
There was an issue in accounting for the implicit `.` and `..` entries in directory listings that was part of the issue in #26 

With this fix, I get the correct output on a linux machine. The described symptoms in #26 imply there may be a secondary issue in mac interactions, since it the disjoint of 27 vs 65 entries is likely that the subsequent pages of entries are not correctly fetched at all, not simply the off-by-two paging issue this commit fixes.