### PR TITLE
Make the cookie verifier stable across multiple readdirplus calls

### DIFF
--- a/dir.go
+++ b/dir.go
@@ -1,0 +1,29 @@
+//go:build !checksumverifier
+
+package nfs
+
+import (
+	"io/fs"
+	"sort"
+
+	"github.com/go-git/go-billy/v5"
+)
+
+func contentsWithVerifier(fs billy.Filesystem, path string) ([]fs.FileInfo, uint64, error) {
+	contents, err := fs.ReadDir(path)
+	if err != nil {
+		return nil, 0, &NFSStatusError{NFSStatusNotDir, err}
+	}
+
+	sort.Slice(contents, func(i, j int) bool {
+		return contents[i].Name() < contents[j].Name()
+	})
+
+	stat, err := fs.Stat(path)
+	if err != nil {
+		return nil, 0, &NFSStatusError{NFSStatusServerFault, err}
+	}
+
+	verifier := uint64(stat.ModTime().UnixMicro())
+	return contents, verifier, nil
+}

--- a/dir_checksum.go
+++ b/dir_checksum.go
@@ -1,0 +1,41 @@
+//go:build checksumverifier
+
+package nfs
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"io/fs"
+	"sort"
+
+	"github.com/go-git/go-billy/v5"
+)
+
+func checksumVerifier(contents []fs.FileInfo) uint64 {
+	//calculate the cookie-verifier for this read-dir exercise.
+	//Note: this is an inefficient way to do this for large directories where
+	//paging actually occurs. however, the billy interface doesn't expose the
+	//granularity to do better, either.
+	vHash := sha256.New()
+
+	for _, c := range contents {
+		vHash.Write([]byte(c.Name())) // Never fails according to the docs
+	}
+
+	verify := vHash.Sum(nil)[0:8]
+	return binary.BigEndian.Uint64(verify)
+}
+
+func contentsWithVerifier(fs billy.Filesystem, path string) ([]fs.FileInfo, uint64, error) {
+	contents, err := fs.ReadDir(path)
+	if err != nil {
+		return nil, 0, &NFSStatusError{NFSStatusNotDir, err}
+	}
+
+	sort.Slice(contents, func(i, j int) bool {
+		return contents[i].Name() < contents[j].Name()
+	})
+
+	verifier := checksumVerifier(contents)
+	return contents, verifier, nil
+}


### PR DESCRIPTION
At least one NFS client seems to expect the nfs verifier cookie to be stable accross more than one call as the current implemenentation does.

There are two options, the default one being using the stat call to the dir to get the modification time-stamp and use that as a verifier.

The advantage is that doesn't need to calculate any checksum, the downside is, that it breaks memfs, which returns always now() as the timestamp.