### PR TITLE
Support more stable cookie verifiers across directory reads.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -33,6 +33,6 @@ type Handler interface {
 // CachingHandler represents the optional caching work that a user may wish to over-ride with
 // their own implementations, but which can be otherwise provided through defaults.
 type CachingHandler interface {
-	VerifierFor(handle []byte, contents []fs.FileInfo) uint64
-	DataForVerifier(handle []byte, verifier uint64) []fs.FileInfo
+	VerifierFor(path string, contents []fs.FileInfo) uint64
+	DataForVerifier(path string, verifier uint64) []fs.FileInfo
 }

--- a/handler.go
+++ b/handler.go
@@ -2,6 +2,7 @@ package nfs
 
 import (
 	"context"
+	"io/fs"
 	"net"
 
 	billy "github.com/go-git/go-billy/v5"
@@ -27,4 +28,11 @@ type Handler interface {
 	FromHandle(fh []byte) (billy.Filesystem, []string, error)
 	// How many handles can be safely maintained by the handler.
 	HandleLimit() int
+}
+
+// CachingHandler represents the optional caching work that a user may wish to over-ride with
+// their own implementations, but which can be otherwise provided through defaults.
+type CachingHandler interface {
+	VerifierFor(handle []byte, contents []fs.FileInfo) uint64
+	DataForVerifier(handle []byte, verifier uint64) ([]fs.FileInfo, error)
 }

--- a/handler.go
+++ b/handler.go
@@ -34,5 +34,5 @@ type Handler interface {
 // their own implementations, but which can be otherwise provided through defaults.
 type CachingHandler interface {
 	VerifierFor(handle []byte, contents []fs.FileInfo) uint64
-	DataForVerifier(handle []byte, verifier uint64) ([]fs.FileInfo, error)
+	DataForVerifier(handle []byte, verifier uint64) []fs.FileInfo
 }

--- a/handler.go
+++ b/handler.go
@@ -34,5 +34,7 @@ type Handler interface {
 // their own implementations, but which can be otherwise provided through defaults.
 type CachingHandler interface {
 	VerifierFor(path string, contents []fs.FileInfo) uint64
+
+	// fs.FileInfo needs to be sorted by Name()
 	DataForVerifier(path string, verifier uint64) []fs.FileInfo
 }

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"bytes"
 	"io/fs"
 	"math/rand"
 
@@ -100,20 +99,20 @@ func hasPrefix(path, prefix []string) bool {
 }
 
 type verifier struct {
-	handle   []byte
+	path     string
 	contents []fs.FileInfo
 }
 
-func (c *CachingHandler) VerifierFor(handle []byte, contents []fs.FileInfo) uint64 {
+func (c *CachingHandler) VerifierFor(path string, contents []fs.FileInfo) uint64 {
 	id := rand.Uint64()
-	c.activeVerifiers.Add(id, verifier{handle, contents})
+	c.activeVerifiers.Add(id, verifier{path, contents})
 	return id
 }
 
-func (c *CachingHandler) DataForVerifier(handle []byte, id uint64) []fs.FileInfo {
+func (c *CachingHandler) DataForVerifier(path string, id uint64) []fs.FileInfo {
 	if cache, ok := c.activeVerifiers.Get(id); ok {
 		f, ok := cache.(verifier)
-		if ok && bytes.Equal(handle, f.handle) {
+		if ok || path == f.path {
 			return f.contents
 		}
 	}

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -109,6 +109,7 @@ func hashPathAndContents(path string, contents []fs.FileInfo) uint64 {
 	vHash := sha256.New()
 
 	// Add the path to avoid collisions of directories with the same content
+	vHash.Write(binary.BigEndian.AppendUint64([]byte{}, uint64(len(path))))
 	vHash.Write([]byte(path))
 
 	for _, c := range contents {
@@ -128,7 +129,7 @@ func (c *CachingHandler) VerifierFor(path string, contents []fs.FileInfo) uint64
 func (c *CachingHandler) DataForVerifier(path string, id uint64) []fs.FileInfo {
 	if cache, ok := c.activeVerifiers.Get(id); ok {
 		f, ok := cache.(verifier)
-		if ok || path == f.path {
+		if ok {
 			return f.contents
 		}
 	}

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -110,12 +110,12 @@ func (c *CachingHandler) VerifierFor(handle []byte, contents []fs.FileInfo) uint
 	return id
 }
 
-func (c *CachingHandler) DataForVerifier(handle []byte, id uint64) ([]fs.FileInfo, error) {
+func (c *CachingHandler) DataForVerifier(handle []byte, id uint64) []fs.FileInfo {
 	if cache, ok := c.activeVerifiers.Get(id); ok {
 		f, ok := cache.(verifier)
 		if ok && bytes.Equal(handle, f.handle) {
-			return f.contents, nil
+			return f.contents
 		}
 	}
-	return nil, &nfs.NFSStatusError{NFSStatus: nfs.NFSStatusBadCookie}
+	return nil
 }

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -190,13 +190,21 @@ func getDirListingWithVerifier(userHandle Handler, fsHandle []byte, verifier uin
 		return contents, v, nil
 	}
 
+	id := hashPathAndContents(path, contents)
+	return contents, id, nil
+}
+
+func hashPathAndContents(path string, contents []fs.FileInfo) uint64 {
 	//calculate a cookie-verifier.
 	vHash := sha256.New()
+
+	// Add the path to avoid collisions of directories with the same content
+	vHash.Write([]byte(path))
 
 	for _, c := range contents {
 		vHash.Write([]byte(c.Name())) // Never fails according to the docs
 	}
 
 	verify := vHash.Sum(nil)[0:8]
-	return contents, binary.BigEndian.Uint64(verify), nil
+	return binary.BigEndian.Uint64(verify)
 }

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -168,10 +168,7 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 func getDirListingWithVerifier(userHandle Handler, fsHandle []byte, verifier uint64) ([]fs.FileInfo, uint64, error) {
 	// see if handle has this dir cached:
 	if vh, ok := userHandle.(CachingHandler); verifier != 0 && ok {
-		entries, err := vh.DataForVerifier(fsHandle, verifier)
-		if err != nil {
-			return nil, 0, err
-		}
+		entries := vh.DataForVerifier(fsHandle, verifier)
 		return entries, verifier, nil
 	}
 

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -46,18 +46,11 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 
 	contents, verifier, err := getDirListingWithVerifier(userHandle, obj.Handle, obj.CookieVerif)
 	if err != nil {
-		if os.IsPermission(err) {
-			return &NFSStatusError{NFSStatusAccess, err}
-		}
-		return &NFSStatusError{NFSStatusNotDir, err}
+		return err
 	}
 	if obj.Cookie > 0 && obj.CookieVerif > 0 && verifier != obj.CookieVerif {
 		return &NFSStatusError{NFSStatusBadCookie, nil}
 	}
-
-	sort.Slice(contents, func(i, j int) bool {
-		return contents[i].Name() < contents[j].Name()
-	})
 
 	entities := make([]readDirEntity, 0)
 	maxBytes := uint32(100) // conservative overhead measure

--- a/server.go
+++ b/server.go
@@ -61,7 +61,7 @@ func (s *Server) Serve(l net.Listener) error {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
 				if tempDelay == 0 {
 					tempDelay = 5 * time.Millisecond
 				} else {


### PR DESCRIPTION
This is an alternative to #49, allowing the user handler to optionally manage verifier management, as it would with handles.
Fix #48 