### PR TITLE
Handle cache-miss in CachingHandler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -35,6 +35,6 @@ type Handler interface {
 type CachingHandler interface {
 	VerifierFor(path string, contents []fs.FileInfo) uint64
 
-	// fs.FileInfo needs to be sorted by Name()
+	// fs.FileInfo needs to be sorted by Name(), nil in case of a cache-miss
 	DataForVerifier(path string, verifier uint64) []fs.FileInfo
 }

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -139,7 +139,9 @@ func getDirListingWithVerifier(userHandle Handler, fsHandle []byte, verifier uin
 	// see if the verifier has this dir cached:
 	if vh, ok := userHandle.(CachingHandler); verifier != 0 && ok {
 		entries := vh.DataForVerifier(path, verifier)
-		return entries, verifier, nil
+		if entries != nil {
+			return entries, verifier, nil
+		}
 	}
 	// load the entries.
 	contents, err := fs.ReadDir(path)


### PR DESCRIPTION
CachingHandler.DataForVerifier may fail to return
contents in case of a cache miss.
Then getDirListingWithVerifier should fall back
to reading the directory normally,
and store the results with CachingHandler.VerifierFor