### PR TITLE
Fixed bug causing SETATTR to always fail when guard is supplied

### DIFF
--- a/time.go
+++ b/time.go
@@ -15,7 +15,7 @@ type FileTime struct {
 func ToNFSTime(t time.Time) FileTime {
 	return FileTime{
 		Seconds:  uint32(t.Unix()),
-		Nseconds: uint32(t.UnixNano()) % uint32(time.Second),
+		Nseconds: uint32(t.UnixNano() % int64(time.Second)),
 	}
 }
 


### PR DESCRIPTION
... due to guard's ctime not matching relevant entry's Ctimespec field.

The reason why the guard's ctime will never match is due to function `ToNFSTime` converting `time.Time.UnixNano()` to `uint32` *before* removing seconds part from the value via a modulo operation.

Since the ctime value in the guard should be coming from a LOOKUP response (or perhaps from some other response that contains entry stats, e.g. GETATTR or READDIRPLUS), and the ctime field in all those responses has been "formatted" via
`ToNFSTime`, there will be no way for a remote call to SETATTR to succeed when guard is being supplied.

This commit fixes the bug in `ToNFSTime` but also changes the guard check in the SETATTR implementation to use the same struct as the one that is being sent in responses that contain entry stats.  This change to the SETATTR implementation is technically unnecessary but (IMO) it should be cleaner and safer.

----------------

Side notes I felt didn't belong in the commit message:

1. The whole "`UnixNano()` converted to `uint32` before modulo operation" thing came as a surprise to me.
Would have thought before that anything cut away from `UnixNano()`'s `int64` would only affect the seconds part of the
value, making it irrelevant when followed up by the modulo operation.  But that seems not to be the case, as verified by
the following go unit test:
```
func TestUnixNano(t *testing.T) {
	unixNano := time.Now().UnixNano()
	castFirst := uint32(unixNano) % uint32(time.Second)
	moduloFirst := uint32(unixNano % int64(time.Second))
	if castFirst != moduloFirst {
		t.Fatalf("castFirst: %v moduloFirst: %v", castFirst, moduloFirst)
	}
}
```
which resulted in the following failure when executed on my machine:
```
--- FAIL: TestUnixNano (0.00s)
    /Users/fridvin/Development/go-nfs/nfs_test.go:26: castFirst: 840636832 moduloFirst: 369220000
```
(perhaps executing the test on a machine with different endianness would succeed? 🤔 🤷).

2. Omitted adding unit test that would perform SETATTR with guard because it seems that billy's in-memory file system
does not persist modification timestamp for entries (AFAICT, billy's in-memory file system implementation for
`os.FileInfo.ModTime()` simply returns `time.Now()`).