### PR TITLE
Fix bug in CREATE when directory is not root

### DIFF
--- a/nfs_oncreate.go
+++ b/nfs_oncreate.go
@@ -60,7 +60,8 @@ func onCreate(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusNameTooLong, nil}
 	}
 
-	newFilePath := fs.Join(append(path, string(obj.Filename))...)
+	newFile := append(path, string(obj.Filename))
+	newFilePath := fs.Join(newFile...)
 	if s, err := fs.Stat(newFilePath); err == nil {
 		if s.IsDir() {
 			return &NFSStatusError{NFSStatusExist, nil}
@@ -86,7 +87,7 @@ func onCreate(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusAccess, err}
 	}
 
-	fp := userHandle.ToHandle(fs, append(path, file.Name()))
+	fp := userHandle.ToHandle(fs, newFile)
 	changer := userHandle.Change(fs)
 	if err := attrs.Apply(changer, fs, newFilePath); err != nil {
 		log.Printf("Error applying attributes: %v\n", err)


### PR DESCRIPTION
... resulting in response containing file handle that is unusable.

Caused by `billy.File.Name()` returning full path instead of just filename. Not sure whether this happens on all platforms but at least happens on Mac. Fix uses same approach as that of MKDIR - using filename from request.