### PR TITLE
pass in fileid from underlying filesystem

### DIFF
--- a/file.go
+++ b/file.go
@@ -113,6 +113,7 @@ func ToFileAttribute(info os.FileInfo) *FileAttribute {
 		f.UID = a.UID
 		f.GID = a.GID
 		f.SpecData = [2]uint32{a.Major, a.Minor}
+		f.Fileid = a.Fileid
 	}
 
 	f.Filesize = uint64(info.Size())

--- a/file/file.go
+++ b/file/file.go
@@ -3,11 +3,12 @@ package file
 import "os"
 
 type FileInfo struct {
-	Nlink uint32
-	UID   uint32
-	GID   uint32
-	Major uint32
-	Minor uint32
+	Nlink  uint32
+	UID    uint32
+	GID    uint32
+	Major  uint32
+	Minor  uint32
+	Fileid uint64
 }
 
 // GetInfo extracts some non-standardized items from the result of a Stat call.

--- a/file/file_unix.go
+++ b/file/file_unix.go
@@ -18,6 +18,7 @@ func getInfo(info os.FileInfo) *FileInfo {
 		fi.GID = s.Gid
 		fi.Major = unix.Major(uint64(s.Rdev))
 		fi.Minor = unix.Minor(uint64(s.Rdev))
+		fi.Fileid = s.Ino
 		return fi
 	}
 	return nil

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -81,8 +81,9 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 				break
 			}
 
+			attrs := ToFileAttribute(c)
 			entities = append(entities, readDirEntity{
-				FileID: 1337, // todo: does this matter?
+				FileID: attrs.Fileid,
 				Name:   []byte(c.Name()),
 				Cookie: cookie,
 				Next:   true,


### PR DESCRIPTION
fix #82 

It's a bit of bad mix layer to rely on underlying inodes being unique to expose uniqueness of files as displayed in the synthetic nfs mount.

I'll put in an issue to be able to generate stable/unique fileids for files for cases where the underlying filesystem info doesn't expose these.