### PR TITLE
Only set file id if it's unset

### DIFF
--- a/nfs_onreaddirplus.go
+++ b/nfs_onreaddirplus.go
@@ -92,7 +92,9 @@ func onReadDirPlus(ctx context.Context, w *response, userHandle Handler) error {
 
 			handle := userHandle.ToHandle(fs, joinPath(p, c.Name()))
 			attrs := ToFileAttribute(c)
-			attrs.Fileid = binary.BigEndian.Uint64(handle[0:8])
+			if attrs.Fileid == 0 {
+				attrs.Fileid = binary.BigEndian.Uint64(handle[0:8])
+			}
 			entities = append(entities, readDirPlusEntity{
 				FileID:     attrs.Fileid,
 				Name:       []byte(c.Name()),


### PR DESCRIPTION
Thanks for the great library! I noticed an issue where the inode numbers on my files were changing, like this:

```
$ ls .mnt/ -li
12899649424779661251 dr-xr-xr-x - bork tags
$ ls .mnt/tags/ -li
2554126253176081818 lr-xr-xr-x 54 bork vtest -> ../commits/ab/ab0a86afc8a176c1afae1faab8b489dcba76c40b
$ ls .mnt/ -li
15722733243342951127 dr-xr-xr-x - bork tags <-- inode number changed
```

I tracked it down to this line of code, where (if I understand correctly) I think the goal is to set an inode number if it's unset. But it was overriding the inode number that I'd already set in my `syscall.Stat_t`, which made things a little weird.

So I thought it might make more sense to only set the inode number if it's unset. This change fixed the issue I was having. I might have misunderstood the intent though.

Basically `attrs.Fileid` gets set on the previous line  ([here](https://github.com/willscott/go-nfs/blob/a91b8b3bf0fd76882bb2f2a2f3c1256405c03f15/file.go#L116)) and it seems weird to immediately overwrite that value