### PR TITLE
use hash of file path for Fileid when not provided.

### DIFF
--- a/nfs_ongetattr.go
+++ b/nfs_ongetattr.go
@@ -19,14 +19,15 @@ func onGetAttr(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusStale, err}
 	}
 
-	info, err := fs.Stat(fs.Join(path...))
+	fullPath := fs.Join(path...)
+	info, err := fs.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}
 		}
 		return &NFSStatusError{NFSStatusIO, err}
 	}
-	attr := ToFileAttribute(info)
+	attr := ToFileAttribute(info, fullPath)
 
 	writer := bytes.NewBuffer([]byte{})
 	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path"
 	"sort"
 
 	"github.com/willscott/go-nfs-client/nfs/xdr"
@@ -81,7 +82,7 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 				break
 			}
 
-			attrs := ToFileAttribute(c)
+			attrs := ToFileAttribute(c, path.Join(append(p, c.Name())...))
 			entities = append(entities, readDirEntity{
 				FileID: attrs.Fileid,
 				Name:   []byte(c.Name()),

--- a/nfs_onreaddirplus.go
+++ b/nfs_onreaddirplus.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"path"
 
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
@@ -90,9 +91,9 @@ func onReadDirPlus(ctx context.Context, w *response, userHandle Handler) error {
 				break
 			}
 
-			handle := userHandle.ToHandle(fs, joinPath(p, c.Name()))
-			attrs := ToFileAttribute(c)
-			attrs.Fileid = binary.BigEndian.Uint64(handle[0:8])
+			filePath := joinPath(p, c.Name())
+			handle := userHandle.ToHandle(fs, filePath)
+			attrs := ToFileAttribute(c, path.Join(filePath...))
 			entities = append(entities, readDirPlusEntity{
 				FileID:     attrs.Fileid,
 				Name:       []byte(c.Name()),

--- a/nfs_onremove.go
+++ b/nfs_onremove.go
@@ -28,7 +28,8 @@ func onRemove(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusNameTooLong, nil}
 	}
 
-	dirInfo, err := fs.Stat(fs.Join(path...))
+	fullPath := fs.Join(path...)
+	dirInfo, err := fs.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}
@@ -41,7 +42,7 @@ func onRemove(ctx context.Context, w *response, userHandle Handler) error {
 	if !dirInfo.IsDir() {
 		return &NFSStatusError{NFSStatusNotDir, nil}
 	}
-	preCacheData := ToFileAttribute(dirInfo).AsCache()
+	preCacheData := ToFileAttribute(dirInfo, fullPath).AsCache()
 
 	toDelete := fs.Join(append(path, string(obj.Filename))...)
 

--- a/nfs_onrename.go
+++ b/nfs_onrename.go
@@ -43,7 +43,8 @@ func onRename(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusNameTooLong, os.ErrInvalid}
 	}
 
-	fromDirInfo, err := fs.Stat(fs.Join(fromPath...))
+	fromDirPath := fs.Join(fromPath...)
+	fromDirInfo, err := fs.Stat(fromDirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}
@@ -53,9 +54,10 @@ func onRename(ctx context.Context, w *response, userHandle Handler) error {
 	if !fromDirInfo.IsDir() {
 		return &NFSStatusError{NFSStatusNotDir, nil}
 	}
-	preCacheData := ToFileAttribute(fromDirInfo).AsCache()
+	preCacheData := ToFileAttribute(fromDirInfo, fromDirPath).AsCache()
 
-	toDirInfo, err := fs.Stat(fs.Join(toPath...))
+	toDirPath := fs.Join(toPath...)
+	toDirInfo, err := fs.Stat(toDirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}
@@ -65,7 +67,7 @@ func onRename(ctx context.Context, w *response, userHandle Handler) error {
 	if !toDirInfo.IsDir() {
 		return &NFSStatusError{NFSStatusNotDir, nil}
 	}
-	preDestData := ToFileAttribute(toDirInfo).AsCache()
+	preDestData := ToFileAttribute(toDirInfo, toDirPath).AsCache()
 
 	fromLoc := fs.Join(append(fromPath, string(from.Filename))...)
 	toLoc := fs.Join(append(toPath, string(to.Filename))...)

--- a/nfs_onsetattr.go
+++ b/nfs_onsetattr.go
@@ -25,7 +25,8 @@ func onSetAttr(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusInval, err}
 	}
 
-	info, err := fs.Lstat(fs.Join(path...))
+	fullPath := fs.Join(path...)
+	info, err := fs.Lstat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}
@@ -42,7 +43,7 @@ func onSetAttr(ctx context.Context, w *response, userHandle Handler) error {
 		if err := xdr.Read(w.req.Body, &t); err != nil {
 			return &NFSStatusError{NFSStatusInval, err}
 		}
-		attr := ToFileAttribute(info)
+		attr := ToFileAttribute(info, fullPath)
 		if t != attr.Ctime {
 			return &NFSStatusError{NFSStatusNotSync, nil}
 		}
@@ -58,7 +59,7 @@ func onSetAttr(ctx context.Context, w *response, userHandle Handler) error {
 		return err
 	}
 
-	preAttr := ToFileAttribute(info).AsCache()
+	preAttr := ToFileAttribute(info, fullPath).AsCache()
 
 	writer := bytes.NewBuffer([]byte{})
 	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {

--- a/nfs_onwrite.go
+++ b/nfs_onwrite.go
@@ -50,7 +50,8 @@ func onWrite(ctx context.Context, w *response, userHandle Handler) error {
 	}
 
 	// stat first for pre-op wcc.
-	info, err := fs.Stat(fs.Join(path...))
+	fullPath := fs.Join(path...)
+	info, err := fs.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}
@@ -60,7 +61,7 @@ func onWrite(ctx context.Context, w *response, userHandle Handler) error {
 	if !info.Mode().IsRegular() {
 		return &NFSStatusError{NFSStatusInval, os.ErrInvalid}
 	}
-	preOpCache := ToFileAttribute(info).AsCache()
+	preOpCache := ToFileAttribute(info, fullPath).AsCache()
 
 	// now the actual op.
 	file, err := fs.OpenFile(fs.Join(path...), os.O_RDWR, info.Mode().Perm())


### PR DESCRIPTION
This is an expansion for a more consistent fix of the issue identified in #96 
It provides a more consistent backup using a hash of file path in cases where the underlying file system doesn't provide a fileid, as introduced in #88 