### PR TITLE
Include wrapped error message in NFSStatusError.Error().

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -172,7 +172,11 @@ type NFSStatusError struct {
 
 // Error is The wrapped error
 func (s *NFSStatusError) Error() string {
-	return s.NFSStatus.String()
+	message := s.NFSStatus.String()
+	if s.WrappedErr != nil {
+		message = fmt.Sprintf("%s: %v", message, s.WrappedErr)
+	}
+	return message
 }
 
 // Code for NFS issues are successful RPC responses


### PR DESCRIPTION
I've found that this has made development and debugging dramatically easier. It also matches the behavior of most wrapping-error types in the Go standard library, so it seems to be kinda the expected idiom.