### PR TITLE
Make handles one-to-one, instead of merely unique

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -27,7 +27,6 @@ type Handler interface {
 	// Can be safely implemented via helpers/cachinghandler.
 	ToHandle(fs billy.Filesystem, path []string) []byte
 	FromHandle(fh []byte) (billy.Filesystem, []string, error)
-	UpdateHandle( billy.Filesystem, billy.Filesystem, []string, []string)
 	InvalidateHandle( billy.Filesystem, []string)
 	
 	// How many handles can be safely maintained by the handler.

--- a/handler.go
+++ b/handler.go
@@ -27,6 +27,9 @@ type Handler interface {
 	// Can be safely implemented via helpers/cachinghandler.
 	ToHandle(fs billy.Filesystem, path []string) []byte
 	FromHandle(fh []byte) (billy.Filesystem, []string, error)
+	UpdateHandle( billy.Filesystem, billy.Filesystem, []string, []string)
+	InvalidateHandle( billy.Filesystem, []string)
+	
 	// How many handles can be safely maintained by the handler.
 	HandleLimit() int
 }

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -121,25 +121,6 @@ func (c *CachingHandler) searchReverseCache (f billy.Filesystem, path []string) 
    return	
 }
 
-func (c *CachingHandler) UpdateHandle( fs billy.Filesystem, fs2 billy.Filesystem, oldPath []string, newPath []string){
-	handle,_,err:=c.searchReverseCache(fs,oldPath)
-	if err!=nil{
-		return
-	}
-	
-	fs, oldPath, err = c.FromHandle(handle) //Normalize to what is in the cache(s)
-	if err != nil{
-		return
-	}
-	
-	c.InvalidateHandle(fs,oldPath) //The oldPath no longer exists in fs
-	
-	//Associate the handle with the newPath
-	id, _ := uuid.FromBytes(handle)
-	c.activeHandles.Add(id,entry{fs2,newPath})
-	c.reverseCache[fs2.Join(newPath...)]=append(c.reverseCache[fs2.Join(newPath...)],[2]any{fs2,handle})
-}
-
 func (c *CachingHandler) InvalidateHandle( fs billy.Filesystem, path []string){
 	handle, i, err := c.searchReverseCache(fs,path)
 	if err!=nil{

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -147,7 +147,7 @@ func (c *CachingHandler) InvalidateHandle( fs billy.Filesystem, path []string){
 	}
 	
 	//Remove from reverseCache
-	joinedPath:=fs.Join(path)
+	joinedPath:=fs.Join(path...)
 	arr:=c.reverseCache[joinedPath]
 	arr[i]=arr[len(arr)-1]
 	c.reverseCache[joinedPath]=arr[:len(arr)-1]

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -49,6 +49,12 @@ func (h *NullAuthHandler) FromHandle([]byte) (billy.Filesystem, []string, error)
 	return nil, []string{}, nil
 }
 
+func (c *NullAuthHandler) UpdateHandle( billy.Filesystem, billy.Filesystem, []string, []string){
+}
+
+func (c *NullAuthHandler) InvalidateHandle( billy.Filesystem, []string){
+}
+
 // HandleLImit handled by cachingHandler
 func (h *NullAuthHandler) HandleLimit() int {
 	return -1

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -49,9 +49,6 @@ func (h *NullAuthHandler) FromHandle([]byte) (billy.Filesystem, []string, error)
 	return nil, []string{}, nil
 }
 
-func (c *NullAuthHandler) UpdateHandle( billy.Filesystem, billy.Filesystem, []string, []string){
-}
-
 func (c *NullAuthHandler) InvalidateHandle( billy.Filesystem, []string){
 }
 

--- a/nfs_onrename.go
+++ b/nfs_onrename.go
@@ -84,7 +84,19 @@ func onRename(ctx context.Context, w *response, userHandle Handler) error {
 		}
 		return &NFSStatusError{NFSStatusIO, err}
 	}
-
+	
+	fromPathCopy:=make([]string,len(fromPath))
+	copy(fromPathCopy,fromPath)
+	
+	if false{ //Just in case a non-compliant client assumes that a Rename does not invalidate any handles
+		toPathCopy:=make([]string,len(toPath))
+		copy(toPathCopy,toPath)
+	
+		userHandle.UpdateHandle(fs, fs2, append(fromPathCopy, string(from.Filename)), append(toPathCopy, string(to.Filename)))
+	}else{
+		userHandle.InvalidateHandle(fs, append(fromPathCopy, string(from.Filename)))
+	}
+	
 	writer := bytes.NewBuffer([]byte{})
 	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {
 		return &NFSStatusError{NFSStatusServerFault, err}

--- a/nfs_onrename.go
+++ b/nfs_onrename.go
@@ -87,15 +87,7 @@ func onRename(ctx context.Context, w *response, userHandle Handler) error {
 	
 	fromPathCopy:=make([]string,len(fromPath))
 	copy(fromPathCopy,fromPath)
-	
-	if false{ //Just in case a non-compliant client assumes that a Rename does not invalidate any handles
-		toPathCopy:=make([]string,len(toPath))
-		copy(toPathCopy,toPath)
-	
-		userHandle.UpdateHandle(fs, fs2, append(fromPathCopy, string(from.Filename)), append(toPathCopy, string(to.Filename)))
-	}else{
-		userHandle.InvalidateHandle(fs, append(fromPathCopy, string(from.Filename)))
-	}
+	userHandle.InvalidateHandle(fs, append(fromPathCopy, string(from.Filename)))
 	
 	writer := bytes.NewBuffer([]byte{})
 	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {


### PR DESCRIPTION
This fixes a bug where getcwd returns ENOENT.