### PR TITLE
Use fs.Lstat when stat'ing files

### DIFF
--- a/file.go
+++ b/file.go
@@ -132,7 +132,7 @@ func ToFileAttribute(info os.FileInfo, filePath string) *FileAttribute {
 // tryStat attempts to create a FileAttribute from a path.
 func tryStat(fs billy.Filesystem, path []string) *FileAttribute {
 	fullPath := fs.Join(path...)
-	attrs, err := fs.Stat(fullPath)
+	attrs, err := fs.Lstat(fullPath)
 	if err != nil || attrs == nil {
 		Log.Errorf("err loading attrs for %s: %v", fs.Join(path...), err)
 		return nil

--- a/nfs_ongetattr.go
+++ b/nfs_ongetattr.go
@@ -20,7 +20,7 @@ func onGetAttr(ctx context.Context, w *response, userHandle Handler) error {
 	}
 
 	fullPath := fs.Join(path...)
-	info, err := fs.Stat(fullPath)
+	info, err := fs.Lstat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &NFSStatusError{NFSStatusNoEnt, err}


### PR DESCRIPTION
to not follow symlinks