### PR TITLE
Allow os.FileInfo impls to provide a *file.FileInfo

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -14,8 +14,12 @@ type FileInfo struct {
 // GetInfo extracts some non-standardized items from the result of a Stat call.
 func GetInfo(fi os.FileInfo) *FileInfo {
 	sys := fi.Sys()
-	if v, ok := sys.(*FileInfo); ok {
+	switch v := sys.(type) {
+	case FileInfo:
+		return &v
+	case *FileInfo:
 		return v
+	default:
+		return getOSFileInfo(fi)
 	}
-	return getOSFileInfo(fi)
 }

--- a/file/file.go
+++ b/file/file.go
@@ -11,7 +11,17 @@ type FileInfo struct {
 	Fileid uint64
 }
 
+// FileInfoGetter allows os.FileInfo implementations that implement
+// the GetFileInfo() method to explicitly return a *FileInfo.
+// Useful for explicitly setting a Fileid without having to use the syscall package
+type FileInfoGetter interface {
+	GetFileInfo() *FileInfo
+}
+
 // GetInfo extracts some non-standardized items from the result of a Stat call.
 func GetInfo(fi os.FileInfo) *FileInfo {
-	return getInfo(fi)
+	if v, ok := fi.(FileInfoGetter); ok {
+		return v.GetFileInfo()
+	}
+	return getOSFileInfo(fi)
 }

--- a/file/file.go
+++ b/file/file.go
@@ -11,17 +11,11 @@ type FileInfo struct {
 	Fileid uint64
 }
 
-// FileInfoGetter allows os.FileInfo implementations that implement
-// the GetFileInfo() method to explicitly return a *FileInfo.
-// Useful for explicitly setting a Fileid without having to use the syscall package
-type FileInfoGetter interface {
-	GetFileInfo() *FileInfo
-}
-
 // GetInfo extracts some non-standardized items from the result of a Stat call.
 func GetInfo(fi os.FileInfo) *FileInfo {
-	if v, ok := fi.(FileInfoGetter); ok {
-		return v.GetFileInfo()
+	sys := fi.Sys()
+	if v, ok := sys.(*FileInfo); ok {
+		return v
 	}
 	return getOSFileInfo(fi)
 }

--- a/file/file_unix.go
+++ b/file/file_unix.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getInfo(info os.FileInfo) *FileInfo {
+func getOSFileInfo(info os.FileInfo) *FileInfo {
 	fi := &FileInfo{}
 	if s, ok := info.Sys().(*syscall.Stat_t); ok {
 		fi.Nlink = uint32(s.Nlink)

--- a/file/file_windows.go
+++ b/file/file_windows.go
@@ -4,7 +4,7 @@ package file
 
 import "os"
 
-func getInfo(info os.FileInfo) *FileInfo {
+func getOSFileInfo(info os.FileInfo) *FileInfo {
 	// https://godoc.org/golang.org/x/sys/windows#GetFileInformationByHandle
 	// can be potentially used to populate Nlink
 


### PR DESCRIPTION
Use case: I have custom logic to determine the NFS File ID. Currently, the only to return it to clients is by returning a `syscall.Stat_t` from `Sys()`, which cannot work on Windows machines.

This PR introduces a small interface, which, if implemented by the `os.FileInfo` implementation, allows returning an explicit `*file.FileInfo`. If unimplemented, existing logic remains, so should be backwards compatible.
