### PR TITLE
conn: remove the log.Errorf for non-NFS protocol errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -127,7 +127,6 @@ func (c *conn) handle(ctx context.Context, w *response) error {
 		return drainErr
 	}
 	if appError != nil && !w.responded {
-		Log.Errorf("call to %+v failed: %v", handler, appError)
 		if err := c.err(ctx, w, appError); err != nil {
 			return err
 		}


### PR DESCRIPTION
The current code is calling log.Errorf for file system errors. File system errors can be frequent, as in a shell searching $PATH.

These errors will be visible to the NFS client, and the NFS server are very confusing when running shells on NFS-mounted file systems, since the shell will handle the error.

The shell is just one example; searches of LD_LIBRARY_PATH, /usr/include, etc: all produce copiuos error messages that are not needed. The error is returned to the client and can be handled there.

Note that if there is a protocol-level error, such as failure to return a response packet, the error prints will still happen. In that case, it may be appropriate.

Fixes #117.