### PR TITLE
Add support for mount export for fuse-nfs

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -20,6 +20,9 @@ type Handler interface {
 
 	// Optional methods - generic helpers or trivial implementations can be sufficient depending on use case.
 
+	// List of all exported file systems.
+	Export(context.Context) []Export
+
 	// Fill in information about a file system's free space.
 	FSStat(context.Context, billy.Filesystem, *FSStat) error
 

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -20,6 +20,7 @@ type NullAuthHandler struct {
 
 // Mount backs Mount RPC Requests, allowing for access control policies.
 func (h *NullAuthHandler) Mount(ctx context.Context, conn net.Conn, req nfs.MountRequest) (status nfs.MountStatus, hndl billy.Filesystem, auths []nfs.AuthFlavor) {
+	_ = req.Dirpath
 	status = nfs.MountStatusOk
 	hndl = h.fs
 	auths = []nfs.AuthFlavor{nfs.AuthFlavorNull}
@@ -32,6 +33,12 @@ func (h *NullAuthHandler) Change(fs billy.Filesystem) billy.Change {
 		return c
 	}
 	return nil
+}
+
+// List of all exported file systems.
+func (h *NullAuthHandler) Export(context.Context) []nfs.Export {
+	groups := []nfs.Group{{Name: []byte("anonymous")}}
+	return []nfs.Export{{Dir: []byte("/mount"), Groups: groups}}
 }
 
 // FSStat provides information about a filesystem.

--- a/mount.go
+++ b/mount.go
@@ -15,6 +15,7 @@ func init() {
 	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcNull), onMountNull)
 	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcMount), onMount)
 	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcUmnt), onUMount)
+	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcExport), onMountExport)
 }
 
 func onMountNull(ctx context.Context, w *response, userHandle Handler) error {
@@ -55,4 +56,19 @@ func onUMount(ctx context.Context, w *response, userHandle Handler) error {
 	}
 
 	return w.writeHeader(ResponseCodeSuccess)
+}
+
+func onMountExport(ctx context.Context, w *response, userHandle Handler) error {
+	exports := userHandle.Export(ctx)
+
+	if err := w.writeHeader(ResponseCodeSuccess); err != nil {
+		return err
+	}
+
+	writer := bytes.NewBuffer([]byte{})
+
+	if err := xdr.Write(writer, exports); err != nil {
+		return err
+	}
+	return w.Write(writer.Bytes())
 }

--- a/mountinterface.go
+++ b/mountinterface.go
@@ -88,3 +88,16 @@ type MountResponse struct {
 	FileHandle
 	AuthFlavors []int
 }
+
+// Group contains a group node, with information about the allowed access group.
+type Group struct {
+	Name []byte
+	Next []Group
+}
+
+// Export contains an export node, with information about an exported filesystem.
+type Export struct {
+	Dir     []byte
+	Groups  []Group
+	Next    []Export
+}


### PR DESCRIPTION
It wants to list the exported file systems, for mount.

But currently the nullauth ignores the dirpath anyway.