### PR TITLE
Use io.WriteAt if available in onWrite

### DIFF
--- a/nfs_onwrite.go
+++ b/nfs_onwrite.go
@@ -68,21 +68,40 @@ func onWrite(ctx context.Context, w *response, userHandle Handler) error {
 	if err != nil {
 		return &NFSStatusError{NFSStatusAccess, err}
 	}
-	if req.Offset > 0 {
-		if _, err := file.Seek(int64(req.Offset), io.SeekStart); err != nil {
-			return &NFSStatusError{NFSStatusIO, err}
+	defer func() {
+		if file != nil {
+			if err := file.Close(); err != nil {
+				Log.Errorf("error closing: %v", err)
+				// Already returning another error
+			}
 		}
-	}
+	}()
+
 	end := req.Count
 	if len(req.Data) < int(end) {
 		end = uint32(len(req.Data))
 	}
-	writtenCount, err := file.Write(req.Data[:end])
-	if err != nil {
-		Log.Errorf("Error writing: %v", err)
-		return &NFSStatusError{NFSStatusIO, err}
+
+	var writtenCount int
+	if writeAt, ok := file.(io.WriterAt); ok {
+		if writtenCount, err = writeAt.WriteAt(req.Data[:end], int64(req.Offset)); err != nil {
+			return &NFSStatusError{NFSStatusIO, err}
+		}
+	} else {
+		if req.Offset > 0 {
+			if _, err := file.Seek(int64(req.Offset), io.SeekStart); err != nil {
+				return &NFSStatusError{NFSStatusIO, err}
+			}
+		}
+		writtenCount, err = file.Write(req.Data[:end])
+		if err != nil {
+			Log.Errorf("Error writing: %v", err)
+			return &NFSStatusError{NFSStatusIO, err}
+		}
 	}
-	if err := file.Close(); err != nil {
+	err = file.Close()
+	file = nil // No more need to close on exit.
+	if err != nil {
 		Log.Errorf("error closing: %v", err)
 		return &NFSStatusError{NFSStatusIO, err}
 	}


### PR DESCRIPTION
The interface io.WriterAt is thread-safe.  Using it allows fs.OpenFile to return the _same_ billy.File instance between different calls.  It also saves a system call.

billy.File does not support io.WriterAt; a comment says it may be added in v6.

Also, plug a file descriptor leak when operations on file fail.

## How was is tested?

In fact, memfs - already used to test go-nfs - does implement WriteAt.  So now go-nfs is tested _only_ with files implementing io.WriterAt.  If this PR is acceptable, I will push another commit.  It will test with _two_ versions of memfs, only one of which will implement WriterAt in its file.