### PR TITLE
fix: default nlink=2 for directories to fix macOS NFS ReadDir

### DIFF
--- a/file.go
+++ b/file.go
@@ -107,7 +107,16 @@ func ToFileAttribute(info os.FileInfo, filePath string) *FileAttribute {
 		f.Type = FileTypeRegular
 	}
 	// The number of hard links to the file.
-	f.Nlink = 1
+	// POSIX convention: directories have nlink >= 2 (self "." + parent entry).
+	// macOS NFS client uses nlink as an optimization hint — nlink == 1 on a
+	// directory signals "no subdirectories" and causes ReadDir to be skipped
+	// entirely. This breaks any virtual filesystem where file.GetInfo returns
+	// nil (no real inode data to populate nlink).
+	if info.IsDir() {
+		f.Nlink = 2
+	} else {
+		f.Nlink = 1
+	}
 
 	if a := file.GetInfo(info); a != nil {
 		f.Nlink = a.Nlink


### PR DESCRIPTION
## Problem

macOS NFS client silently skips `ReadDir` when a directory reports `nlink=1`, interpreting it as having no subdirectories. This breaks **any** go-nfs consumer that uses a virtual billy.Filesystem where `file.GetInfo()` returns nil (no real inode/syscall.Stat_t data).

When `GetInfo` returns nil, `ToFileAttribute` defaults `Nlink` to 1 for everything — including directories. On Linux this works fine (the NFS client calls ReadDir regardless). On macOS, it silently produces empty directory listings or hangs.

`nfsstat -c` confirms: 255 Getattr calls, 321 Lookups, **0 Readdir, 0 ReaddirPlus** — macOS never even attempts to list directory contents.

## Root Cause

`ToFileAttribute()` in `file.go` unconditionally sets `f.Nlink = 1` before checking `GetInfo`. Virtual filesystems don't have real stat data, so `GetInfo` returns nil and the default of 1 persists for directories.

POSIX convention is that directories always have nlink ≥ 2 (`.` self-link + parent entry). macOS NFS client uses this as an optimization hint — nlink=1 on a directory signals "no subdirectories, skip ReadDir." While the NFS spec (RFC 1813) doesn't mandate a minimum nlink for directories, returning 1 violates the POSIX convention that macOS depends on.

## Fix

Default `nlink` to 2 for directories, 1 for files, **before** the `GetInfo` check. Real filesystems with actual inode data are completely unaffected since `GetInfo` overwrites the default when it succeeds.

One-line semantic change, no behavioral change for real filesystems.

## Testing

- All existing tests pass (`go test ./...`)
- Verified fix resolves macOS NFS ReadDir hang with TigerFS (Timescale's Postgres-backed virtual filesystem)
- Tested on macOS 15.3 (Sequoia) with Apple's built-in NFS client
- `nfsstat -c` confirms Readdir calls resume after fix