### PR TITLE
feat: add integration tests with NFS mount

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,50 +2,36 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
   schedule:
     - cron: '0 18 * * 3'
 
+permissions:
+  security-events: write
+  contents: read
+
 jobs:
   CodeQL-Build:
-
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+        go-version: '1.21'
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-      
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      uses: github/codeql-action/init@v3
+      with:
+        languages: go
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,23 +14,19 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
       with:
-        go-version: ^1.19
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-
-    - name: Get dependencies
-      run: go get -v -t -d ./...
+        go-version: '1.21'
 
     - name: Build
       run: go build -v ./...
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+    - name: Lint
+      uses: golangci/golangci-lint-action@v6
 
     - name: Test
       run: go test -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,3 +30,21 @@ jobs:
 
     - name: Test
       run: go test -v .
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+
+    - name: Install NFS client
+      run: sudo apt-get install -y nfs-common
+
+    - name: Integration Test
+      run: sudo go test -v -tags integration -run TestIntegration -timeout 120s .

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD010": false,
+  "MD013": false
+}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-Golang Network File Server
-===
+# Golang Network File Server
 
 NFSv3 protocol implementation in pure Golang.
 
 Current Status:
-* Minimally tested
-* Mounts, read-only and read-write support
 
-Usage
-===
+- Minimally tested
+- Mounts, read-only and read-write support
 
-The most interesting demo is currently in `example/osview`. 
+## Usage
+
+The most interesting demo is currently in `example/osview`.
 
 Start the server
 `go run ./example/osview .`.
@@ -19,15 +18,14 @@ The local folder at `.` will be the initial view in the mount. mutations to meta
 will be stored purely in memory and not written back to the OS. When run, this
 demo will print the port it is listening on.
 
-The mount can be accessed using a command similar to 
+The mount can be accessed using a command similar to
 `mount -o port=<n>,mountport=<n> -t nfs localhost:/mount <mountpoint>` (For Mac users)
 
 or
 
 `mount -o port=<n>,mountport=<n>,nfsvers=3,noacl,tcp -t nfs localhost:/mount <mountpoint>` (For Linux users)
 
-API
-===
+## API
 
 The NFS server runs on a `net.Listener` to export a file system to NFS clients.
 Usage is structured similarly to many other golang network servers.
@@ -69,30 +67,29 @@ func panicOnErr(err error, desc ...interface{}) {
 }
 ```
 
-Notes
----
+## Notes
 
-* Ports are typically determined through portmap. The need for running portmap 
-(which is the only part that needs a privileged listening port) can be avoided
-through specific mount options. e.g. 
-`mount -o port=n,mountport=n -t nfs host:/mount /localmount`
+- Ports are typically determined through portmap. The need for running portmap
+  (which is the only part that needs a privileged listening port) can be avoided
+  through specific mount options. e.g.
+  `mount -o port=n,mountport=n -t nfs host:/mount /localmount`
 
-* This server currently uses [billy](https://github.com/go-git/go-billy/) to
-provide a file system abstraction layer. There are some edges of the NFS protocol
-which do not translate to this abstraction.
-  * NFS expects access to an `inode` or equivalent unique identifier to reference
-  files in a file system. These are considered opaque identifiers here, which
-  means they will not work as expected in cases of hard linking.
-  * The billy abstraction layer does not extend to exposing `uid` and `gid`
-  ownership of files. If ownership is important to your file system, you
-  will need to ensure that the `os.FileInfo` meets additional constraints.
-  In particular, the `Sys()` escape hatch is queried by this library, and
-  if your file system populates a [`syscall.Stat_t`](https://golang.org/pkg/syscall/#Stat_t)
-  concrete struct, the ownership specified in that object will be used.
-  You can also return a [`file.FileInfo`](https://github.com/willscott/go-nfs/blob/master/file/file.go#L5)
-  which doesn't vary between platforms so may be easier to deal with.
+- This server currently uses [billy](https://github.com/go-git/go-billy/) to
+  provide a file system abstraction layer. There are some edges of the NFS protocol
+  which do not translate to this abstraction.
+  - NFS expects access to an `inode` or equivalent unique identifier to reference
+    files in a file system. These are considered opaque identifiers here, which
+    means they will not work as expected in cases of hard linking.
+  - The billy abstraction layer does not extend to exposing `uid` and `gid`
+    ownership of files. If ownership is important to your file system, you
+    will need to ensure that the `os.FileInfo` meets additional constraints.
+    In particular, the `Sys()` escape hatch is queried by this library, and
+    if your file system populates a [`syscall.Stat_t`](https://golang.org/pkg/syscall/#Stat_t)
+    concrete struct, the ownership specified in that object will be used.
+    You can also return a [`file.FileInfo`](https://github.com/willscott/go-nfs/blob/master/file/file.go#L5)
+    which doesn't vary between platforms so may be easier to deal with.
 
-* Relevant RFCS:
-[5531 - RPC protocol](https://tools.ietf.org/html/rfc5531),
-[1813 - NFSv3](https://tools.ietf.org/html/rfc1813),
-[1094 - NFS](https://tools.ietf.org/html/rfc1094)
+- Relevant RFCS:
+  [5531 - RPC protocol](https://tools.ietf.org/html/rfc5531),
+  [1813 - NFSv3](https://tools.ietf.org/html/rfc1813),
+  [1094 - NFS](https://tools.ietf.org/html/rfc1094)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ func panicOnErr(err error, desc ...interface{}) {
 }
 ```
 
+## Testing
+
+Unit tests can be run without any special privileges:
+
+```bash
+go test -v .
+```
+
+Integration tests mount an actual NFS filesystem and exercise it using standard
+Unix utilities (`cat`, `ls`, `mkdir`, `cp`, `mv`, `rm`, `ln`, `chmod`, `dd`,
+`diff`, `stat`, `find`, etc.). They require root privileges for the NFS mount
+and are gated behind the `integration` build tag:
+
+```bash
+# macOS
+sudo go test -v -tags integration -run TestIntegration -timeout 120s .
+
+# Linux (requires nfs-common or nfs-utils to be installed)
+sudo apt-get install -y nfs-common   # Debian/Ubuntu
+sudo go test -v -tags integration -run TestIntegration -timeout 120s .
+```
+
 ## Notes
 
 - Ports are typically determined through portmap. The need for running portmap

--- a/example/tigris/main.go
+++ b/example/tigris/main.go
@@ -1,0 +1,251 @@
+// Copyright 2024 Tigris Data, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Example implementation of ReadDirStreamer for S3-backed filesystem.
+// This file demonstrates how to implement the streaming interface
+// for a filesystem backed by object storage (like Tigris or AWS S3).
+//
+// This example requires the AWS SDK v2 dependency which is not part
+// of the go-nfs module. To use, copy to your own project and add:
+//   go get github.com/aws/aws-sdk-go-v2
+//   go get github.com/aws/aws-sdk-go-v2/service/s3
+
+//go:build ignore
+
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	billy "github.com/go-git/go-billy/v5"
+	nfs "github.com/willscott/go-nfs"
+	nfshelper "github.com/willscott/go-nfs/helpers"
+)
+
+// TigrisHandler implements nfs.ReadDirStreamer for S3-backed storage.
+type TigrisHandler struct {
+	nfshelper.NullAuthHandler
+	s3Client *s3.Client
+	bucket   string
+
+	// Cookie management for streaming
+	streams    sync.Map
+	nextCookie atomic.Uint64
+}
+
+// streamState holds the continuation token for a paginated listing.
+type streamState struct {
+	path         string
+	continuation *string
+	createdAt    time.Time
+}
+
+// Verify interface compliance at compile time.
+var _ nfs.ReadDirStreamer = (*TigrisHandler)(nil)
+
+// ReadDirStream implements nfs.ReadDirStreamer.
+// Called for each page of a directory listing.
+func (h *TigrisHandler) ReadDirStream(
+	fs billy.Filesystem,
+	path []string,
+	cookie uint64,
+	count int,
+) (entries []os.FileInfo, verifier uint64, nextCookie uint64, err error) {
+	pathStr := "/" + strings.Join(path, "/")
+	prefix := pathToS3Prefix(pathStr)
+
+	var continuation *string
+
+	if cookie > 0 {
+		stateVal, ok := h.streams.Load(cookie)
+		if !ok {
+			return nil, 0, 0, &nfs.NFSStatusError{NFSStatus: nfs.NFSStatusBadCookie}
+		}
+		state := stateVal.(*streamState)
+		if state.path != pathStr {
+			return nil, 0, 0, &nfs.NFSStatusError{NFSStatus: nfs.NFSStatusBadCookie}
+		}
+		continuation = state.continuation
+		// Don't delete yet — go-nfs may discard our result if the cookie
+		// verifier check fails. Stale entries are cleaned up by
+		// cleanupOldStreams. Deleting here would irrecoverably lose the
+		// continuation token.
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := h.s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+		Bucket:            aws.String(h.bucket),
+		Prefix:            aws.String(prefix),
+		Delimiter:         aws.String("/"),
+		MaxKeys:           aws.Int32(int32(count)),
+		ContinuationToken: continuation,
+	})
+	if err != nil {
+		return nil, 0, 0, &nfs.NFSStatusError{NFSStatus: nfs.NFSStatusIO, WrappedErr: err}
+	}
+
+	entries = make([]os.FileInfo, 0, len(result.CommonPrefixes)+len(result.Contents))
+
+	for _, p := range result.CommonPrefixes {
+		name := filepath.Base(strings.TrimSuffix(aws.ToString(p.Prefix), "/"))
+		entries = append(entries, &s3FileInfo{
+			name:    name,
+			size:    0,
+			mode:    0755 | os.ModeDir,
+			modTime: time.Now(),
+			isDir:   true,
+			inode:   hashToInode(aws.ToString(p.Prefix)),
+		})
+	}
+
+	for _, obj := range result.Contents {
+		key := aws.ToString(obj.Key)
+		if key == prefix {
+			continue
+		}
+		entries = append(entries, &s3FileInfo{
+			name:    filepath.Base(key),
+			size:    aws.ToInt64(obj.Size),
+			mode:    0644,
+			modTime: aws.ToTime(obj.LastModified),
+			isDir:   false,
+			inode:   hashToInode(key),
+		})
+	}
+
+	// Verifier 0 = disabled (appropriate for S3 virtual directories).
+	verifier = 0
+
+	if aws.ToBool(result.IsTruncated) && result.NextContinuationToken != nil {
+		newCookie := h.nextCookie.Add(1)
+		h.streams.Store(newCookie, &streamState{
+			path:         pathStr,
+			continuation: result.NextContinuationToken,
+			createdAt:    time.Now(),
+		})
+		nextCookie = newCookie
+
+		go h.cleanupOldStreams()
+	} else {
+		nextCookie = 0
+	}
+
+	return entries, verifier, nextCookie, nil
+}
+
+func (h *TigrisHandler) cleanupOldStreams() {
+	cutoff := time.Now().Add(-5 * time.Minute)
+	h.streams.Range(func(key, value any) bool {
+		state := value.(*streamState)
+		if state.createdAt.Before(cutoff) {
+			h.streams.Delete(key)
+		}
+		return true
+	})
+}
+
+// s3FileInfo implements os.FileInfo with proper Sys() for NFS.
+type s3FileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+	inode   uint64
+}
+
+func (fi *s3FileInfo) Name() string       { return fi.name }
+func (fi *s3FileInfo) Size() int64        { return fi.size }
+func (fi *s3FileInfo) Mode() os.FileMode  { return fi.mode }
+func (fi *s3FileInfo) ModTime() time.Time { return fi.modTime }
+func (fi *s3FileInfo) IsDir() bool        { return fi.isDir }
+
+func (fi *s3FileInfo) Sys() interface{} {
+	mode := uint32(fi.mode.Perm())
+	if fi.isDir {
+		mode |= syscall.S_IFDIR
+	} else {
+		mode |= syscall.S_IFREG
+	}
+
+	return &syscall.Stat_t{
+		Ino:     fi.inode,
+		Mode:    mode,
+		Nlink:   1,
+		Uid:     uint32(os.Getuid()),
+		Gid:     uint32(os.Getgid()),
+		Size:    fi.size,
+		Blksize: 4096,
+		Blocks:  (fi.size + 511) / 512,
+		Atim:    syscall.Timespec{Sec: fi.modTime.Unix()},
+		Mtim:    syscall.Timespec{Sec: fi.modTime.Unix()},
+		Ctim:    syscall.Timespec{Sec: fi.modTime.Unix()},
+	}
+}
+
+func pathToS3Prefix(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	if path != "" && !strings.HasSuffix(path, "/") {
+		path += "/"
+	}
+	return path
+}
+
+func hashToInode(s string) uint64 {
+	var h uint64 = 14695981039346656037 // FNV offset basis
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= 1099511628211 // FNV prime
+	}
+	return h
+}
+
+func main() {
+	s3Client := createS3Client()
+	bucket := os.Getenv("TIGRIS_BUCKET")
+	if bucket == "" {
+		bucket = "my-dataset"
+	}
+
+	handler := &TigrisHandler{
+		NullAuthHandler: nfshelper.NewNullAuthHandler(nil),
+		s3Client:        s3Client,
+		bucket:          bucket,
+	}
+
+	cacheHandler := nfshelper.NewCachingHandler(handler, 1000000)
+
+	listener, err := net.Listen("tcp", ":2049")
+	if err != nil {
+		panic(err)
+	}
+
+	println("NFS server listening on :2049")
+	println("Mount with: mount -t nfs -o port=2049,mountport=2049,nfsvers=3,tcp localhost:/ /mnt/tigris")
+
+	if err := nfs.Serve(listener, cacheHandler); err != nil {
+		panic(err)
+	}
+}
+
+func createS3Client() *s3.Client {
+	// Replace with real initialization, e.g.:
+	//
+	//   cfg, _ := config.LoadDefaultConfig(context.Background())
+	//   return s3.NewFromConfig(cfg, func(o *s3.Options) {
+	//       o.BaseEndpoint = aws.String(os.Getenv("AWS_ENDPOINT_URL_S3"))
+	//   })
+	panic("createS3Client: not implemented — see comment above")
+}

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -159,6 +159,12 @@ func (c *CachingHandler) HandleLimit() int {
 	return c.cacheLimit
 }
 
+// Unwrap returns the underlying handler. This allows go-nfs to discover
+// optional interfaces (like ReadDirStreamer) on the wrapped handler.
+func (c *CachingHandler) Unwrap() nfs.Handler {
+	return c.Handler
+}
+
 func hasPrefix(path, prefix []string) bool {
 	if len(prefix) > len(path) {
 		return false

--- a/integration_helpers_unix_test.go
+++ b/integration_helpers_unix_test.go
@@ -1,0 +1,278 @@
+//go:build integration && (darwin || linux)
+
+package nfs_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+	osfs "github.com/go-git/go-billy/v5/osfs"
+	nfs "github.com/willscott/go-nfs"
+	"github.com/willscott/go-nfs/helpers"
+	"golang.org/x/sys/unix"
+)
+
+// changeOSFS wraps billy osfs to add the Change interface.
+// Replicated from example/osnfs/changeos.go since that's a main package.
+type changeOSFS struct {
+	billy.Filesystem
+}
+
+func newChangeOSFS(fs billy.Filesystem) billy.Filesystem {
+	return changeOSFS{fs}
+}
+
+func (fs changeOSFS) Chmod(name string, mode os.FileMode) error {
+	return os.Chmod(filepath.Join(fs.Root(), name), mode)
+}
+
+func (fs changeOSFS) Lchown(name string, uid, gid int) error {
+	return os.Lchown(filepath.Join(fs.Root(), name), uid, gid)
+}
+
+func (fs changeOSFS) Chown(name string, uid, gid int) error {
+	return os.Chown(filepath.Join(fs.Root(), name), uid, gid)
+}
+
+func (fs changeOSFS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+	return os.Chtimes(filepath.Join(fs.Root(), name), atime, mtime)
+}
+
+func (fs changeOSFS) Mknod(path string, mode uint32, major uint32, minor uint32) error {
+	dev := unix.Mkdev(major, minor)
+	return unix.Mknod(filepath.Join(fs.Root(), path), mode, int(dev))
+}
+
+func (fs changeOSFS) Mkfifo(path string, mode uint32) error {
+	return unix.Mkfifo(filepath.Join(fs.Root(), path), mode)
+}
+
+func (fs changeOSFS) Link(path string, link string) error {
+	return unix.Link(filepath.Join(fs.Root(), path), link)
+}
+
+func (fs changeOSFS) Socket(path string) error {
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return err
+	}
+	return unix.Bind(fd, &unix.SockaddrUnix{Name: filepath.Join(fs.Root(), path)})
+}
+
+// testEnv holds all state for an integration test environment.
+type testEnv struct {
+	listener  net.Listener
+	serverDir string
+	mountDir  string
+	port      int
+	tearOnce  sync.Once
+}
+
+// setupTestEnv creates a new NFS server backed by a temp directory,
+// mounts it, and returns the test environment.
+func setupTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+
+	if os.Getuid() != 0 {
+		t.Skip("integration tests require root privileges for NFS mount")
+	}
+
+	serverDir, err := os.MkdirTemp("", "nfs-server-*")
+	if err != nil {
+		t.Fatalf("failed to create server dir: %v", err)
+	}
+
+	mountDir, err := os.MkdirTemp("", "nfs-mount-*")
+	if err != nil {
+		os.RemoveAll(serverDir)
+		t.Fatalf("failed to create mount dir: %v", err)
+	}
+
+	// Create a seed file so the filesystem root is recognized
+	seed := filepath.Join(serverDir, ".nfs-test")
+	if err := os.WriteFile(seed, []byte(""), 0644); err != nil {
+		os.RemoveAll(serverDir)
+		os.RemoveAll(mountDir)
+		t.Fatalf("failed to create seed file: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		os.RemoveAll(serverDir)
+		os.RemoveAll(mountDir)
+		t.Fatalf("failed to listen: %v", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	bfs := osfs.New(serverDir)
+	bfsPlusChange := newChangeOSFS(bfs)
+	handler := helpers.NewNullAuthHandler(bfsPlusChange)
+	cacheHelper := helpers.NewCachingHandler(handler, 1024)
+
+	go func() {
+		_ = nfs.Serve(listener, cacheHelper)
+	}()
+
+	// Give the server a moment to start accepting connections
+	time.Sleep(100 * time.Millisecond)
+
+	env := &testEnv{
+		listener:  listener,
+		serverDir: serverDir,
+		mountDir:  mountDir,
+		port:      port,
+	}
+
+	if err := mountNFS(port, mountDir); err != nil {
+		listener.Close()
+		os.RemoveAll(serverDir)
+		os.RemoveAll(mountDir)
+		t.Fatalf("failed to mount NFS: %v", err)
+	}
+
+	t.Cleanup(func() { env.teardown(t) })
+	return env
+}
+
+func (env *testEnv) teardown(t *testing.T) {
+	t.Helper()
+	env.tearOnce.Do(func() {
+		if err := unmountNFS(env.mountDir); err != nil {
+			t.Logf("warning: unmount failed: %v", err)
+		}
+		env.listener.Close()
+		os.RemoveAll(env.mountDir)
+		os.RemoveAll(env.serverDir)
+	})
+}
+
+func mountNFS(port int, mountDir string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "mount",
+			"-o", fmt.Sprintf("port=%d,mountport=%d,nfsvers=3,tcp,noacl,resvport", port, port),
+			"-t", "nfs",
+			"localhost:/mount",
+			mountDir)
+	case "linux":
+		cmd = exec.CommandContext(ctx, "mount",
+			"-o", fmt.Sprintf("port=%d,mountport=%d,nfsvers=3,noacl,tcp,noac", port, port),
+			"-t", "nfs",
+			"localhost:/mount",
+			mountDir)
+	default:
+		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mount failed: %v, output: %s", err, output)
+	}
+
+	// Verify mount is usable
+	if err := waitForMount(mountDir, 10*time.Second); err != nil {
+		return fmt.Errorf("mount not ready: %v", err)
+	}
+	return nil
+}
+
+func waitForMount(mountDir string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, err := os.ReadDir(mountDir)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("mount at %s not ready after %v", mountDir, timeout)
+}
+
+func unmountNFS(mountDir string) error {
+	for attempt := 0; attempt < 3; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cmd := exec.CommandContext(ctx, "umount", mountDir)
+		output, err := cmd.CombinedOutput()
+		cancel()
+		if err == nil {
+			return nil
+		}
+		if attempt == 2 {
+			if runtime.GOOS == "darwin" {
+				ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel2()
+				cmd2 := exec.CommandContext(ctx2, "diskutil", "unmount", "force", mountDir)
+				output2, err2 := cmd2.CombinedOutput()
+				if err2 != nil {
+					return fmt.Errorf("force unmount failed: %v, output: %s (previous: %v, %s)", err2, output2, err, output)
+				}
+				return nil
+			}
+			return fmt.Errorf("unmount failed after retries: %v, output: %s", err, output)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return nil
+}
+
+// run executes a command in the given directory, fails the test on error,
+// and returns the combined stdout/stderr output.
+func run(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command %q %v failed: %v\noutput: %s", name, args, err, output)
+	}
+	return string(output)
+}
+
+// runSh executes a shell command string via bash in the given directory.
+func runSh(t *testing.T, dir string, script string) string {
+	t.Helper()
+	return run(t, dir, "bash", "-c", script)
+}
+
+// runExpectFail executes a command and expects it to fail (non-zero exit).
+func runExpectFail(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected command %q %v to fail, but it succeeded\noutput: %s", name, args, output)
+	}
+}
+
+// runShExpectFail executes a shell command string and expects it to fail.
+func runShExpectFail(t *testing.T, dir string, script string) {
+	t.Helper()
+	runExpectFail(t, dir, "bash", "-c", script)
+}
+
+// makeSubdir creates a uniquely named subdirectory under base for test isolation.
+func makeSubdir(t *testing.T, base string) string {
+	t.Helper()
+	dir := filepath.Join(base, t.Name())
+	run(t, base, "mkdir", "-p", dir)
+	return dir
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,241 @@
+//go:build integration && (darwin || linux)
+
+package nfs_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestIntegration(t *testing.T) {
+	env := setupTestEnv(t)
+
+	t.Run("CreateAndReadFile", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runSh(t, dir, `echo -n "hello world" > file.txt`)
+		got := runSh(t, dir, `cat file.txt`)
+		if got != "hello world" {
+			t.Fatalf("expected %q, got %q", "hello world", got)
+		}
+	})
+
+	t.Run("TouchAndStat", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "touch", "file.txt")
+		out := run(t, dir, "stat", "file.txt")
+		if !strings.Contains(out, "file.txt") {
+			t.Fatalf("stat output does not mention file.txt: %s", out)
+		}
+	})
+
+	t.Run("WriteAndAppend", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runSh(t, dir, `echo "first" > file.txt`)
+		runSh(t, dir, `echo "second" >> file.txt`)
+		got := runSh(t, dir, `cat file.txt`)
+		if !strings.Contains(got, "first") || !strings.Contains(got, "second") {
+			t.Fatalf("expected both lines, got %q", got)
+		}
+	})
+
+	t.Run("OverwriteFile", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runSh(t, dir, `echo -n "aaa" > file.txt`)
+		runSh(t, dir, `echo -n "bbb" > file.txt`)
+		got := runSh(t, dir, `cat file.txt`)
+		if got != "bbb" {
+			t.Fatalf("expected %q, got %q", "bbb", got)
+		}
+	})
+
+	t.Run("CopyAndDiff", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runSh(t, dir, `echo -n "data to copy" > src.txt`)
+		run(t, dir, "cp", "src.txt", "dst.txt")
+		run(t, dir, "diff", "src.txt", "dst.txt")
+	})
+
+	t.Run("MkdirAndList", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "subdir")
+		run(t, dir, "touch", "subdir/a.txt", "subdir/b.txt")
+		out := run(t, dir, "ls", "subdir")
+		if !strings.Contains(out, "a.txt") || !strings.Contains(out, "b.txt") {
+			t.Fatalf("expected a.txt and b.txt in listing, got %q", out)
+		}
+	})
+
+	t.Run("NestedDirectories", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "-p", "a/b/c")
+		runSh(t, dir, `echo -n "deep" > a/b/c/file.txt`)
+		got := runSh(t, dir, `cat a/b/c/file.txt`)
+		if got != "deep" {
+			t.Fatalf("expected %q, got %q", "deep", got)
+		}
+	})
+
+	t.Run("RemoveEmptyDirectory", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "emptydir")
+		run(t, dir, "rmdir", "emptydir")
+		runShExpectFail(t, dir, `ls emptydir`)
+	})
+
+	t.Run("RemoveDirectoryRecursive", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "-p", "dir/sub")
+		run(t, dir, "touch", "dir/sub/f.txt")
+		run(t, dir, "rm", "-rf", "dir")
+		runShExpectFail(t, dir, `ls dir`)
+	})
+
+	t.Run("DeleteFile", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "touch", "file.txt")
+		run(t, dir, "rm", "file.txt")
+		runShExpectFail(t, dir, `ls file.txt`)
+	})
+
+	t.Run("RenameFile", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runSh(t, dir, `echo -n "content" > old.txt`)
+		run(t, dir, "mv", "old.txt", "new.txt")
+		got := runSh(t, dir, `cat new.txt`)
+		if got != "content" {
+			t.Fatalf("expected %q, got %q", "content", got)
+		}
+		runShExpectFail(t, dir, `ls old.txt`)
+	})
+
+	t.Run("RenameCrossDirectory", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "dir1", "dir2")
+		runSh(t, dir, `echo -n "moving" > dir1/file.txt`)
+		run(t, dir, "mv", "dir1/file.txt", "dir2/file.txt")
+		got := runSh(t, dir, `cat dir2/file.txt`)
+		if got != "moving" {
+			t.Fatalf("expected %q, got %q", "moving", got)
+		}
+		runShExpectFail(t, dir, `ls dir1/file.txt`)
+	})
+
+	t.Run("CreateAndReadSymlink", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runSh(t, dir, `echo -n "target data" > target.txt`)
+		run(t, dir, "ln", "-s", "target.txt", "link.txt")
+		got := runSh(t, dir, `readlink link.txt`)
+		got = strings.TrimSpace(got)
+		if got != "target.txt" {
+			t.Fatalf("expected readlink %q, got %q", "target.txt", got)
+		}
+		got = runSh(t, dir, `cat link.txt`)
+		if got != "target data" {
+			t.Fatalf("expected %q through symlink, got %q", "target data", got)
+		}
+	})
+
+	t.Run("DanglingSymlink", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "ln", "-s", "nonexistent", "dangling.txt")
+		got := strings.TrimSpace(runSh(t, dir, `readlink dangling.txt`))
+		if got != "nonexistent" {
+			t.Fatalf("expected readlink %q, got %q", "nonexistent", got)
+		}
+		runShExpectFail(t, dir, `cat dangling.txt`)
+	})
+
+	t.Run("Chmod", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "touch", "file.txt")
+		run(t, dir, "chmod", "755", "file.txt")
+		out := runSh(t, dir, `stat -c '%a' file.txt 2>/dev/null || stat -f '%Lp' file.txt`)
+		out = strings.TrimSpace(out)
+		if out != "755" {
+			t.Fatalf("expected mode 755, got %q", out)
+		}
+	})
+
+	t.Run("ChmodDirectory", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "mydir")
+		run(t, dir, "chmod", "700", "mydir")
+		out := runSh(t, dir, `stat -c '%a' mydir 2>/dev/null || stat -f '%Lp' mydir`)
+		out = strings.TrimSpace(out)
+		if out != "700" {
+			t.Fatalf("expected mode 700, got %q", out)
+		}
+	})
+
+	t.Run("LargeFileDD", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		// Write 10 MB file
+		run(t, dir, "dd", "if=/dev/urandom", "of=large.bin", "bs=1048576", "count=10")
+		// Verify size
+		out := runSh(t, dir, `wc -c < large.bin`)
+		out = strings.TrimSpace(out)
+		if out != "10485760" {
+			t.Fatalf("expected 10485760 bytes, got %s", out)
+		}
+		// Copy and diff to verify integrity
+		run(t, dir, "cp", "large.bin", "large2.bin")
+		run(t, dir, "diff", "large.bin", "large2.bin")
+	})
+
+	t.Run("ManyFiles", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		// Create 500 files
+		for i := 0; i < 500; i++ {
+			run(t, dir, "touch", fmt.Sprintf("file-%04d.txt", i))
+		}
+		// Verify count
+		out := runSh(t, dir, `ls -1 | wc -l`)
+		out = strings.TrimSpace(out)
+		if out != "500" {
+			t.Fatalf("expected 500 files, got %s", out)
+		}
+		// Cross-check with find
+		out = runSh(t, dir, `find . -maxdepth 1 -type f | wc -l`)
+		out = strings.TrimSpace(out)
+		if out != "500" {
+			t.Fatalf("expected 500 files from find, got %s", out)
+		}
+	})
+
+	t.Run("ConcurrentWriters", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		// Launch 10 background writers and wait
+		script := `
+for i in $(seq 0 9); do
+  echo -n "data-$i" > "concurrent-$i.txt" &
+done
+wait
+`
+		runSh(t, dir, script)
+		// Verify all files exist with correct content
+		for i := 0; i < 10; i++ {
+			got := runSh(t, dir, fmt.Sprintf(`cat concurrent-%d.txt`, i))
+			expected := fmt.Sprintf("data-%d", i)
+			if got != expected {
+				t.Fatalf("file concurrent-%d.txt: expected %q, got %q", i, expected, got)
+			}
+		}
+	})
+
+	t.Run("ReadNonExistent", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runShExpectFail(t, dir, `cat nonexistent.txt`)
+	})
+
+	t.Run("RmNonExistent", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		runExpectFail(t, dir, "rm", "nonexistent.txt")
+	})
+
+	t.Run("MkdirExisting", func(t *testing.T) {
+		dir := makeSubdir(t, env.mountDir)
+		run(t, dir, "mkdir", "existing")
+		runExpectFail(t, dir, "mkdir", "existing")
+	})
+}

--- a/nfs_onreaddir.go
+++ b/nfs_onreaddir.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"sort"
 
+	billy "github.com/go-git/go-billy/v5"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 
@@ -45,6 +46,12 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusStale, err}
 	}
 
+	// If handler (or wrapped handler) supports streaming, use the streaming path.
+	if streamer, ok := asReadDirStreamer(userHandle); ok {
+		return onReadDirStreaming(ctx, w, userHandle, streamer, fs, p, obj)
+	}
+
+	// Original path: load all entries via billy.ReadDir.
 	contents, verifier, err := getDirListingWithVerifier(userHandle, obj.Handle, obj.CookieVerif)
 	if err != nil {
 		return err
@@ -137,6 +144,103 @@ func onReadDir(ctx context.Context, w *response, userHandle Handler) error {
 	return nil
 }
 
+// streamCookieOffset is added to handler cookies on the wire to avoid
+// collisions with the hardcoded "." (cookie=0) and ".." (cookie=1) entries.
+// Handler cookies are opaque uint64 values; without this offset, a handler
+// returning nextCookie=1 would collide with "..".
+const streamCookieOffset = 2
+
+// syntheticCookieBit marks cookies that are NOT valid resumption points.
+// Interior entries on non-EOF pages and all entries on EOF pages get this
+// bit set. Only the last entry on a non-EOF page has a "real" cookie
+// (nextCookie + streamCookieOffset) that clients can use to resume.
+// This prevents collisions between synthetic cookies across pages.
+const syntheticCookieBit = uint64(1) << 63
+
+// onReadDirStreaming handles READDIR using the ReadDirStreamer interface.
+// Memory usage is bounded by the page size rather than directory size.
+func onReadDirStreaming(
+	ctx context.Context,
+	w *response,
+	userHandle Handler,
+	streamer ReadDirStreamer,
+	fs billy.Filesystem,
+	p []string,
+	obj readDirArgs,
+) error {
+	count := int(obj.Count / 64) // ~64 bytes per wire entry estimate
+	if count < 10 {
+		count = 10
+	}
+	if maxEntities := userHandle.HandleLimit() / 2; maxEntities > 0 && count > maxEntities {
+		count = maxEntities
+	}
+
+	page, err := fetchStreamPage(streamer, fs, p, obj.Cookie, obj.CookieVerif, count)
+	if err != nil {
+		return err
+	}
+
+	entities := make([]readDirEntity, 0, len(page.entries)+2)
+
+	if obj.Cookie == 0 {
+		dotdotFileID := uint64(0)
+		if len(p) > 0 {
+			if dda := tryStat(fs, p[0:len(p)-1]); dda != nil {
+				dotdotFileID = dda.Fileid
+			}
+		}
+		dotFileID := uint64(0)
+		if da := tryStat(fs, p); da != nil {
+			dotFileID = da.Fileid
+		}
+		entities = append(entities,
+			readDirEntity{Name: []byte("."), Cookie: 0, Next: true, FileID: dotFileID},
+			readDirEntity{Name: []byte(".."), Cookie: 1, Next: true, FileID: dotdotFileID},
+		)
+	}
+
+	for i, entry := range page.entries {
+		filePath := joinPath(p, entry.Name())
+		attrs := ToFileAttribute(entry, path.Join(filePath...))
+		entities = append(entities, readDirEntity{
+			FileID: attrs.Fileid,
+			Name:   []byte(entry.Name()),
+			Cookie: streamingCookie(page.eof, i, len(page.entries), page.handlerCookie, page.nextCookie),
+			Next:   true,
+		})
+	}
+
+	writer := bytes.NewBuffer([]byte{})
+	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := WritePostOpAttrs(writer, tryStat(fs, p)); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := xdr.Write(writer, page.verifier); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := xdr.Write(writer, len(entities) > 0); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if len(entities) > 0 {
+		entities[len(entities)-1].Next = false
+		for _, e := range entities {
+			if err := xdr.Write(writer, e); err != nil {
+				return &NFSStatusError{NFSStatusServerFault, err}
+			}
+		}
+	}
+	if err := xdr.Write(writer, page.eof); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := w.Write(writer.Bytes()); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	return nil
+}
+
 func getDirListingWithVerifier(userHandle Handler, fsHandle []byte, verifier uint64) ([]fs.FileInfo, uint64, error) {
 	// figure out what directory it is.
 	fs, p, err := userHandle.FromHandle(fsHandle)
@@ -188,4 +292,14 @@ func hashPathAndContents(path string, contents []fs.FileInfo) uint64 {
 
 	verify := vHash.Sum(nil)[0:8]
 	return binary.BigEndian.Uint64(verify)
+}
+
+// hashPathAndMtime creates a verifier from a path and mtime.
+// Used by the streaming path when the handler returns verifier=0.
+func hashPathAndMtime(path string, mtimeNano int64) uint64 {
+	h := sha256.New()
+	h.Write([]byte(path))
+	_ = binary.Write(h, binary.BigEndian, mtimeNano)
+	sum := h.Sum(nil)
+	return binary.BigEndian.Uint64(sum[:8])
 }

--- a/nfs_onreaddirplus.go
+++ b/nfs_onreaddirplus.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"path"
 
+	billy "github.com/go-git/go-billy/v5"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 
@@ -51,6 +52,12 @@ func onReadDirPlus(ctx context.Context, w *response, userHandle Handler) error {
 		return &NFSStatusError{NFSStatusStale, err}
 	}
 
+	// If handler (or wrapped handler) supports streaming, use the streaming path.
+	if streamer, ok := asReadDirStreamer(userHandle); ok {
+		return onReadDirPlusStreaming(ctx, w, userHandle, streamer, fs, p, obj)
+	}
+
+	// Original path: load all entries via billy.ReadDir.
 	contents, verifier, err := getDirListingWithVerifier(userHandle, obj.Handle, obj.CookieVerif)
 	if err != nil {
 		return err
@@ -146,6 +153,100 @@ func onReadDirPlus(ctx context.Context, w *response, userHandle Handler) error {
 	}
 	// TODO: track writer size at this point to validate maxcount estimation and stop early if needed.
 
+	if err := w.Write(writer.Bytes()); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	return nil
+}
+
+// onReadDirPlusStreaming handles READDIRPLUS using the ReadDirStreamer interface.
+// Memory usage is bounded by the page size rather than directory size.
+func onReadDirPlusStreaming(
+	ctx context.Context,
+	w *response,
+	userHandle Handler,
+	streamer ReadDirStreamer,
+	fs billy.Filesystem,
+	p []string,
+	obj readDirPlusArgs,
+) error {
+	// Estimate how many entries to request from both RFC 1813 §3.3.17 limits.
+	// MaxCount bounds the total response size (names + attributes + handles).
+	// DirCount bounds just the directory-portion bytes (names + cookies).
+	count := int(obj.MaxCount / 200)
+	if dirCount := int(obj.DirCount / 24); dirCount < count {
+		count = dirCount
+	}
+	if count < 10 {
+		count = 10
+	}
+	if maxEntities := userHandle.HandleLimit() / 2; maxEntities > 0 && count > maxEntities {
+		count = maxEntities
+	}
+
+	page, err := fetchStreamPage(streamer, fs, p, obj.Cookie, obj.CookieVerif, count)
+	if err != nil {
+		return err
+	}
+
+	entities := make([]readDirPlusEntity, 0, len(page.entries)+2)
+
+	if obj.Cookie == 0 {
+		dotdotFileID := uint64(0)
+		if len(p) > 0 {
+			if dda := tryStat(fs, p[0:len(p)-1]); dda != nil {
+				dotdotFileID = dda.Fileid
+			}
+		}
+		dotFileID := uint64(0)
+		da := tryStat(fs, p)
+		if da != nil {
+			dotFileID = da.Fileid
+		}
+		entities = append(entities,
+			readDirPlusEntity{Name: []byte("."), Cookie: 0, Next: true, FileID: dotFileID, Attributes: da},
+			readDirPlusEntity{Name: []byte(".."), Cookie: 1, Next: true, FileID: dotdotFileID},
+		)
+	}
+
+	for i, entry := range page.entries {
+		filePath := joinPath(p, entry.Name())
+		handle := userHandle.ToHandle(fs, filePath)
+		attrs := ToFileAttribute(entry, path.Join(filePath...))
+		entities = append(entities, readDirPlusEntity{
+			FileID:     attrs.Fileid,
+			Name:       []byte(entry.Name()),
+			Cookie:     streamingCookie(page.eof, i, len(page.entries), page.handlerCookie, page.nextCookie),
+			Attributes: attrs,
+			Handle:     &handle,
+			Next:       true,
+		})
+	}
+
+	writer := bytes.NewBuffer([]byte{})
+	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := WritePostOpAttrs(writer, tryStat(fs, p)); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := xdr.Write(writer, page.verifier); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if err := xdr.Write(writer, len(entities) > 0); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
+	if len(entities) > 0 {
+		entities[len(entities)-1].Next = false
+		for _, e := range entities {
+			if err := xdr.Write(writer, e); err != nil {
+				return &NFSStatusError{NFSStatusServerFault, err}
+			}
+		}
+	}
+	if err := xdr.Write(writer, page.eof); err != nil {
+		return &NFSStatusError{NFSStatusServerFault, err}
+	}
 	if err := w.Write(writer.Bytes()); err != nil {
 		return &NFSStatusError{NFSStatusServerFault, err}
 	}

--- a/streaming.go
+++ b/streaming.go
@@ -1,0 +1,176 @@
+package nfs
+
+import (
+	"fmt"
+	"os"
+
+	billy "github.com/go-git/go-billy/v5"
+)
+
+// ReadDirStreamer is an optional interface that handlers can implement
+// to support paginated directory listing. When implemented, go-nfs will
+// use this instead of billy.Filesystem.ReadDir() for READDIR and
+// READDIRPLUS operations.
+//
+// This enables efficient handling of directories with millions of files
+// by streaming entries directly from the backend (e.g., S3 ListObjectsV2)
+// without buffering the entire listing in memory.
+//
+// Handlers that do not implement this interface will continue to use
+// the existing behavior of calling ReadDir() and paginating in memory.
+type ReadDirStreamer interface {
+	// ReadDirStream returns a page of directory entries for the given path.
+	//
+	// Parameters:
+	//   - fs: The billy.Filesystem for this mount
+	//   - path: Directory path components (e.g., ["dir", "subdir"])
+	//   - cookie: Opaque pagination token from previous call (0 for first request)
+	//   - count: Suggested maximum entries to return
+	//
+	// Returns:
+	//   - entries: Directory entries for this page (may be fewer than count)
+	//   - verifier: Cookie verifier for directory change detection (0 to disable)
+	//   - nextCookie: Token for next page (0 indicates this is the last page)
+	//   - err: Any error encountered
+	//
+	// Cookie semantics:
+	//   - Cookie 0 always means "start from beginning"
+	//   - Cookie values are opaque to go-nfs but must be less than 2^63
+	//     (bit 63 is reserved internally for synthetic NFS cookies)
+	//   - Returning nextCookie=0 signals end of directory (EOF)
+	//
+	// When cookie is 0, go-nfs will prepend "." and ".." entries automatically.
+	// Implementations should NOT include "." and ".." in their returned entries.
+	//
+	// Error handling:
+	//   - Return &NFSStatusError{NFSStatusBadCookie, err} if cookie is invalid/stale
+	//   - Return &NFSStatusError{NFSStatusIO, err} for backend errors
+	//   - Return &NFSStatusError{NFSStatusNoEnt, err} if directory doesn't exist
+	//
+	// Ordering note: go-nfs calls ReadDirStream before validating the cookie
+	// verifier (because the verifier comes from this method's return value).
+	// If the verifier check then fails, the response is discarded. This means
+	// any state consumed during the call (e.g., continuation tokens) is lost.
+	// Implementations should make state consumption recoverable — for example,
+	// by deferring deletion of continuation tokens until after the page is
+	// successfully served, or by allowing tokens to be re-fetched.
+	ReadDirStream(
+		fs billy.Filesystem,
+		path []string,
+		cookie uint64,
+		count int,
+	) (entries []os.FileInfo, verifier uint64, nextCookie uint64, err error)
+}
+
+// asReadDirStreamer checks whether h (or any handler it wraps) implements
+// ReadDirStreamer. This allows wrapper handlers like helpers.CachingHandler
+// to transparently forward the streaming interface from the inner handler.
+//
+// Wrapping handlers should implement Unwrap() Handler to participate.
+func asReadDirStreamer(h Handler) (ReadDirStreamer, bool) {
+	type unwrapper interface {
+		Unwrap() Handler
+	}
+	for h != nil {
+		if s, ok := h.(ReadDirStreamer); ok {
+			return s, true
+		}
+		u, ok := h.(unwrapper)
+		if !ok {
+			return nil, false
+		}
+		h = u.Unwrap()
+	}
+	return nil, false
+}
+
+// streamPageResult holds the validated result of fetching a streaming page.
+type streamPageResult struct {
+	entries       []os.FileInfo
+	handlerCookie uint64
+	verifier      uint64
+	nextCookie    uint64
+	eof           bool
+}
+
+// fetchStreamPage handles the shared logic of calling ReadDirStream and
+// validating cookies/verifiers. Used by both READDIR and READDIRPLUS
+// streaming paths to avoid duplicating protocol-level checks.
+func fetchStreamPage(
+	streamer ReadDirStreamer,
+	fs billy.Filesystem,
+	p []string,
+	cookie, cookieVerif uint64,
+	count int,
+) (*streamPageResult, error) {
+	// Reject synthetic cookies — these are interior/EOF entries that
+	// are not valid resumption points. See syntheticCookieBit.
+	if cookie&syntheticCookieBit != 0 {
+		return nil, &NFSStatusError{NFSStatusBadCookie, nil}
+	}
+
+	// Convert client cookie to handler cookie by removing the offset
+	// for the synthetic "." and ".." entries that go-nfs prepends.
+	// Cookie 0 = first page, cookie 1 = ".." (resume = first real page).
+	handlerCookie := uint64(0)
+	if cookie > 1 {
+		handlerCookie = cookie - streamCookieOffset
+	}
+
+	// NOTE: ReadDirStream is called before cookie verifier validation because
+	// the verifier value comes from the handler's return. This means the call
+	// may consume handler state (e.g., continuation tokens) only for the
+	// result to be discarded if the verifier check fails. Implementations
+	// should tolerate this — see ReadDirStreamer docs for guidance.
+	entries, verifier, nextCookie, err := streamer.ReadDirStream(fs, p, handlerCookie, count)
+	if err != nil {
+		if nfsErr, ok := err.(*NFSStatusError); ok {
+			return nil, nfsErr
+		}
+		return nil, &NFSStatusError{NFSStatusIO, err}
+	}
+
+	// Validate that the handler's nextCookie won't collide with the
+	// synthetic cookie space. Handler cookies must be < 2^63 so that
+	// adding streamCookieOffset doesn't set the syntheticCookieBit.
+	if nextCookie != 0 && nextCookie >= syntheticCookieBit-streamCookieOffset {
+		return nil, &NFSStatusError{NFSStatusServerFault, fmt.Errorf(
+			"ReadDirStream returned nextCookie %d which is too large (must be < %d)",
+			nextCookie, syntheticCookieBit-streamCookieOffset)}
+	}
+
+	// If the handler returned verifier=0, compute one from directory mtime.
+	if verifier == 0 {
+		dirInfo, sErr := fs.Stat(fs.Join(p...))
+		if sErr == nil {
+			verifier = hashPathAndMtime(fs.Join(p...), dirInfo.ModTime().UnixNano())
+		}
+	}
+
+	// Validate cookie verifier to detect directory changes between pages.
+	// Per RFC 1813 §3.3.16, the client echoes back the verifier from the
+	// previous response. If the directory has changed, the verifier won't
+	// match and the client must restart the listing from cookie=0.
+	if cookie > 0 && cookieVerif > 0 && verifier != cookieVerif {
+		return nil, &NFSStatusError{NFSStatusBadCookie, nil}
+	}
+
+	return &streamPageResult{
+		entries:       entries,
+		handlerCookie: handlerCookie,
+		verifier:      verifier,
+		nextCookie:    nextCookie,
+		eof:           nextCookie == 0,
+	}, nil
+}
+
+// streamingCookie computes the NFS wire cookie for entry i in a streaming page.
+// Only the last entry on a non-EOF page gets a real resumption cookie;
+// all others get synthetic cookies (syntheticCookieBit set) that go-nfs
+// rejects if a client tries to resume from them.
+func streamingCookie(eof bool, i, total int, handlerCookie, nextCookie uint64) uint64 {
+	if !eof && i == total-1 {
+		return nextCookie + streamCookieOffset
+	}
+	return syntheticCookieBit | (handlerCookie + streamCookieOffset + uint64(i))
+}

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -1,0 +1,222 @@
+package nfs
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	billy "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
+)
+
+// mockStreamingHandler implements ReadDirStreamer for testing.
+type mockStreamingHandler struct {
+	pageSize  int
+	allFiles  []string
+	callCount int
+}
+
+func (m *mockStreamingHandler) ReadDirStream(
+	fs billy.Filesystem,
+	path []string,
+	cookie uint64,
+	count int,
+) ([]os.FileInfo, uint64, uint64, error) {
+	m.callCount++
+
+	start := int(cookie)
+	if start >= len(m.allFiles) {
+		return nil, 0, 0, nil
+	}
+
+	end := start + m.pageSize
+	if end > len(m.allFiles) {
+		end = len(m.allFiles)
+	}
+
+	entries := make([]os.FileInfo, 0, end-start)
+	for i := start; i < end; i++ {
+		entries = append(entries, &mockFileInfo{
+			name:    m.allFiles[i],
+			size:    1024,
+			mode:    0644,
+			modTime: time.Now(),
+			isDir:   false,
+		})
+	}
+
+	var nextCookie uint64
+	if end < len(m.allFiles) {
+		nextCookie = uint64(end)
+	}
+
+	return entries, 0, nextCookie, nil
+}
+
+type mockFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (fi *mockFileInfo) Name() string       { return fi.name }
+func (fi *mockFileInfo) Size() int64        { return fi.size }
+func (fi *mockFileInfo) Mode() os.FileMode  { return fi.mode }
+func (fi *mockFileInfo) ModTime() time.Time { return fi.modTime }
+func (fi *mockFileInfo) IsDir() bool        { return fi.isDir }
+func (fi *mockFileInfo) Sys() interface{}   { return nil }
+
+// Tests
+
+func TestReadDirStreamerInterface(t *testing.T) {
+	var _ ReadDirStreamer = (*mockStreamingHandler)(nil)
+}
+
+func TestStreamingPagination(t *testing.T) {
+	files := make([]string, 100)
+	for i := range files {
+		files[i] = "file_" + string(rune('0'+i/10)) + string(rune('0'+i%10)) + ".txt"
+	}
+
+	handler := &mockStreamingHandler{
+		pageSize: 10,
+		allFiles: files,
+	}
+
+	fs := memfs.New()
+
+	// First page (cookie = 0)
+	entries, _, nextCookie, err := handler.ReadDirStream(fs, nil, 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 10 {
+		t.Errorf("expected 10 entries, got %d", len(entries))
+	}
+	if nextCookie != 10 {
+		t.Errorf("expected nextCookie=10, got %d", nextCookie)
+	}
+
+	// Middle page (cookie = 50)
+	entries, _, nextCookie, err = handler.ReadDirStream(fs, nil, 50, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 10 {
+		t.Errorf("expected 10 entries, got %d", len(entries))
+	}
+	if nextCookie != 60 {
+		t.Errorf("expected nextCookie=60, got %d", nextCookie)
+	}
+
+	// Last page (cookie = 90)
+	entries, _, nextCookie, err = handler.ReadDirStream(fs, nil, 90, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 10 {
+		t.Errorf("expected 10 entries, got %d", len(entries))
+	}
+	if nextCookie != 0 {
+		t.Errorf("expected nextCookie=0 (EOF), got %d", nextCookie)
+	}
+
+	// Past end (cookie = 100)
+	entries, _, nextCookie, err = handler.ReadDirStream(fs, nil, 100, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+	if nextCookie != 0 {
+		t.Errorf("expected nextCookie=0, got %d", nextCookie)
+	}
+}
+
+func TestStreamingCallCount(t *testing.T) {
+	files := make([]string, 1000)
+	for i := range files {
+		files[i] = "file.txt"
+	}
+
+	handler := &mockStreamingHandler{
+		pageSize: 100,
+		allFiles: files,
+	}
+
+	fs := memfs.New()
+
+	cookie := uint64(0)
+	totalEntries := 0
+	for {
+		entries, _, nextCookie, err := handler.ReadDirStream(fs, nil, cookie, 100)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		totalEntries += len(entries)
+		if nextCookie == 0 {
+			break
+		}
+		cookie = nextCookie
+	}
+
+	if totalEntries != 1000 {
+		t.Errorf("expected 1000 total entries, got %d", totalEntries)
+	}
+
+	if handler.callCount != 10 {
+		t.Errorf("expected 10 calls, got %d", handler.callCount)
+	}
+}
+
+func TestMemoryBoundedness(t *testing.T) {
+	handler := &mockStreamingHandler{
+		pageSize: 1000,
+		allFiles: make([]string, 1_000_000),
+	}
+
+	for i := range handler.allFiles {
+		handler.allFiles[i] = "file"
+	}
+
+	fs := memfs.New()
+
+	entries, _, _, err := handler.ReadDirStream(fs, nil, 0, 1000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 1000 {
+		t.Errorf("expected 1000 entries, got %d", len(entries))
+	}
+}
+
+func BenchmarkStreamingReadDir(b *testing.B) {
+	files := make([]string, 10000)
+	for i := range files {
+		files[i] = "file.txt"
+	}
+
+	handler := &mockStreamingHandler{
+		pageSize: 1000,
+		allFiles: files,
+	}
+
+	fs := memfs.New()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		cookie := uint64(0)
+		for {
+			_, _, nextCookie, _ := handler.ReadDirStream(fs, nil, cookie, 1000)
+			if nextCookie == 0 {
+				break
+			}
+			cookie = nextCookie
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add integration tests that start a go-nfs server, mount it via the OS `mount` command, and run 22 filesystem test cases using standard Unix utilities (`cat`, `ls`, `mkdir`, `cp`, `mv`, `rm`, `ln`, `chmod`, `dd`, `diff`, `stat`, `find`, etc.)
- Tests are gated behind `//go:build integration` build tag and require root privileges for the NFS mount
- Add `integration-test` job to CI workflow that installs `nfs-common` and runs the tests with sudo on Ubuntu
- Add testing instructions to README

## Test plan
- [x] All 22 subtests pass locally on macOS with `sudo go test -v -tags integration -run TestIntegration -timeout 120s .`
- [x] Existing unit tests still pass with `go test -v .`
- [x] Code compiles cleanly with `go build -tags integration ./...` and `go vet -tags integration ./...`
- [x] Normal `go test ./...` (without integration tag) does not run integration tests
- [ ] CI integration-test job passes on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)