### PR TITLE
nfs: fix EOF flag in READ response not being set when read reaches end of file

### DIFF
--- a/nfs_onread.go
+++ b/nfs_onread.go
@@ -25,11 +25,6 @@ type nfsReadResponse struct {
 // MaxRead is the advertised largest buffer the server is willing to read
 const MaxRead = 1 << 24
 
-// CheckRead is a size where - if a request to read is larger than this,
-// the server will stat the file to learn it's actual size before allocating
-// a buffer to read into.
-const CheckRead = 1 << 15
-
 func onRead(ctx context.Context, w *response, userHandle Handler) error {
 	w.errorFmt = opAttrErrorFormatter
 	var obj nfsReadArgs
@@ -52,15 +47,19 @@ func onRead(ctx context.Context, w *response, userHandle Handler) error {
 	defer fh.Close()
 
 	resp := nfsReadResponse{}
+	setEOF := false
 
-	if obj.Count > CheckRead {
-		info, err := fs.Stat(fs.Join(path...))
-		if err != nil {
-			return &NFSStatusError{NFSStatusAccess, err}
-		}
-		if info.Size()-int64(obj.Offset) < int64(obj.Count) {
-			obj.Count = uint32(uint64(info.Size()) - obj.Offset)
-		}
+	fullPath := fs.Join(path...)
+	info, err := fs.Stat(fullPath)
+	if err != nil {
+		return &NFSStatusError{NFSStatusAccess, err}
+	}
+	if int64(obj.Offset) >= info.Size() {
+		obj.Count = 0
+		setEOF = true
+	} else if info.Size()-int64(obj.Offset) <= int64(obj.Count) {
+		obj.Count = uint32(uint64(info.Size()) - obj.Offset)
+		setEOF = true
 	}
 	if obj.Count > MaxRead {
 		obj.Count = MaxRead
@@ -73,7 +72,7 @@ func onRead(ctx context.Context, w *response, userHandle Handler) error {
 	}
 	resp.Count = uint32(cnt)
 	resp.Data = resp.Data[:resp.Count]
-	if errors.Is(err, io.EOF) {
+	if errors.Is(err, io.EOF) || setEOF {
 		resp.EOF = 1
 	}
 
@@ -81,7 +80,7 @@ func onRead(ctx context.Context, w *response, userHandle Handler) error {
 	if err := xdr.Write(writer, uint32(NFSStatusOk)); err != nil {
 		return &NFSStatusError{NFSStatusServerFault, err}
 	}
-	if err := WritePostOpAttrs(writer, tryStat(fs, path)); err != nil {
+	if err := WritePostOpAttrs(writer, ToFileAttribute(info, fullPath)); err != nil {
 		return &NFSStatusError{NFSStatusServerFault, err}
 	}
 

--- a/nfs_test.go
+++ b/nfs_test.go
@@ -2,7 +2,9 @@ package nfs_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"os"
@@ -172,7 +174,7 @@ func TestNFS(t *testing.T) {
 	}
 	defer mf.Close()
 	buf := make([]byte, len(b))
-	if _, err = mf.Read(buf[:]); err != nil {
+	if _, err = mf.Read(buf[:]); err != nil && !errors.Is(err, io.EOF) {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(buf, b) {
@@ -374,4 +376,203 @@ func readDir(target *nfsc.Target, dir string) ([]*readDirEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// nfsRead issues a raw NFS READ RPC and returns the count, eof flag, and data.
+func nfsRead(target *nfsc.Target, filePath string, offset uint64, count uint32) (uint32, bool, []byte, error) {
+	_, fh, err := target.Lookup(filePath)
+	if err != nil {
+		return 0, false, nil, err
+	}
+
+	type readArgs struct {
+		rpc.Header
+		Handle []byte
+		Offset uint64
+		Count  uint32
+	}
+
+	res, err := target.Call(&readArgs{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Vers:    nfsc.Nfs3Vers,
+			Prog:    nfsc.Nfs3Prog,
+			Proc:    uint32(nfs.NFSProcedureRead),
+			Cred:    rpc.AuthNull,
+			Verf:    rpc.AuthNull,
+		},
+		Handle: fh,
+		Offset: offset,
+		Count:  count,
+	})
+	if err != nil {
+		return 0, false, nil, err
+	}
+
+	status, err := xdr.ReadUint32(res)
+	if err != nil {
+		return 0, false, nil, err
+	}
+	if err = nfsc.NFS3Error(status); err != nil {
+		return 0, false, nil, err
+	}
+
+	// Read response using same structure as the NFS client
+	type readRes struct {
+		Attr  nfsc.PostOpAttr
+		Count uint32
+		EOF   uint32
+		Data  struct {
+			Length uint32
+		}
+	}
+	var readResp readRes
+	if err = xdr.Read(res, &readResp); err != nil {
+		return 0, false, nil, err
+	}
+	data := make([]byte, readResp.Data.Length)
+	if readResp.Data.Length > 0 {
+		if _, err = io.ReadFull(res, data); err != nil {
+			return 0, false, nil, err
+		}
+	}
+
+	return readResp.Count, readResp.EOF != 0, data, nil
+}
+
+func TestReadEOF(t *testing.T) {
+	if testing.Verbose() {
+		util.DefaultLogger.SetDebug(true)
+	}
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mem := memfs.New()
+
+	// Create a 64KB file with random content.
+	const fileSize = 64 * 1024
+	fileData := make([]byte, fileSize)
+	if _, err := rand.Read(fileData); err != nil {
+		t.Fatal(err)
+	}
+	f, err := mem.Create("/testfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(fileData); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	handler := helpers.NewNullAuthHandler(mem)
+	cacheHelper := helpers.NewCachingHandler(handler, 1024)
+	go func() {
+		_ = nfs.Serve(listener, cacheHelper)
+	}()
+
+	c, err := rpc.DialTCP(listener.Addr().Network(), listener.Addr().(*net.TCPAddr).String(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	var mounter nfsc.Mount
+	mounter.Client = c
+	target, err := mounter.Mount("/", rpc.AuthNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = mounter.Unmount()
+	}()
+
+	// Small mid-file read: should NOT set EOF
+	cnt, eof, data, err := nfsRead(target, "/testfile", 0, 16*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 16*1024 {
+		t.Fatalf("small mid-file read: expected count %d, got %d", 16*1024, cnt)
+	}
+	if eof {
+		t.Fatal("small mid-file read: EOF should not be set")
+	}
+	if !bytes.Equal(data, fileData[:16*1024]) {
+		t.Fatal("small mid-file read: data mismatch")
+	}
+
+	// Small read that reaches exactly EOF: should set EOF
+	cnt, eof, data, err = nfsRead(target, "/testfile", 48*1024, 16*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 16*1024 {
+		t.Fatalf("small end-of-file read: expected count %d, got %d", 16*1024, cnt)
+	}
+	if !eof {
+		t.Fatal("small end-of-file read: EOF should be set")
+	}
+	if !bytes.Equal(data, fileData[48*1024:]) {
+		t.Fatal("small end-of-file read: data mismatch")
+	}
+
+	// Large mid-file read: should NOT set EOF
+	cnt, eof, data, err = nfsRead(target, "/testfile", 0, 40*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 40*1024 {
+		t.Fatalf("mid-file read: expected count %d, got %d", 40*1024, cnt)
+	}
+	if eof {
+		t.Fatal("mid-file read: EOF should not be set")
+	}
+	if !bytes.Equal(data, fileData[:40*1024]) {
+		t.Fatal("mid-file read: data mismatch")
+	}
+
+	// Read that reaches exactly the end of file (offset+count == filesize): should set EOF
+	cnt, eof, data, err = nfsRead(target, "/testfile", 24*1024, 40*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 40*1024 {
+		t.Fatalf("end-of-file read: expected count %d, got %d", 40*1024, cnt)
+	}
+	if !eof {
+		t.Fatal("end-of-file read: EOF should be set")
+	}
+	if !bytes.Equal(data, fileData[24*1024:]) {
+		t.Fatal("end-of-file read: data mismatch")
+	}
+
+	// Read that extends past EOF (count > remaining): should set EOF with trimmed count
+	cnt, eof, data, err = nfsRead(target, "/testfile", 60*1024, 40*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 4*1024 {
+		t.Fatalf("past-EOF read: expected count %d, got %d", 4*1024, cnt)
+	}
+	if !eof {
+		t.Fatal("past-EOF read: EOF should be set")
+	}
+	if !bytes.Equal(data, fileData[60*1024:]) {
+		t.Fatal("past-EOF read: data mismatch")
+	}
+
+	// Read at offset == filesize: should set EOF with count=0
+	cnt, eof, _, err = nfsRead(target, "/testfile", fileSize, 40*1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cnt != 0 {
+		t.Fatalf("at-EOF read: expected count 0, got %d", cnt)
+	}
+	if !eof {
+		t.Fatal("at-EOF read: EOF should be set")
+	}
 }


### PR DESCRIPTION
When the READ buffer was trimmed to the remaining file bytes (either
by the old CheckRead stat-and-trim path for large reads, or when the
request happened to match exactly), ReadAt would fill the buffer
completely and return nil instead of io.EOF, so the EOF flag was never
set in the response, violating RFC 1813. Most NFS Clients don't care
but some do.

Fix by always stat-ing the file up front to detect when the read will
reach (or pass) the end of file. Reuse that same stat result for the
post-op attributes in the response, replacing the separate
tryStat/Lstat call. This reduces the number of stat calls from two to
one for large reads, and keeps it at one for small reads (which
previously skipped the stat entirely and could miss EOF).

Note: the post-op attributes now use Stat (follows symlinks) instead
of the previous Lstat (does not follow symlinks). This is more correct
for a READ response since the data comes from the real file.

The now-unused CheckRead constant has been removed.
