### PR TITLE
Recover panics in request handler dispatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We appreciate your interest in improving go-nfs!
 ## Looking for ways to contribute?
 
 There are several ways you can contribute:
-- Start contributing immediately via the [opened](https://github.com/willscott/go-nfs/issues) issues on GitHub.
+- Start contributing immediately via the [opened](https://github.com/treeverse/go-nfs/issues) issues on GitHub.
   Defined issues provide an excellent starting point.
 - Reporting issues, bugs, mistakes, or inconsistencies.
   As many open source projects, we are short-staffed, we thus kindly ask you to be open to contribute a fix for discovered issues.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v6/memfs"
 	nfs "github.com/willscott/go-nfs"
 	nfshelper "github.com/willscott/go-nfs/helpers"
 )

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ import (
 	"net"
 
 	"github.com/go-git/go-billy/v6/memfs"
-	nfs "github.com/willscott/go-nfs"
-	nfshelper "github.com/willscott/go-nfs/helpers"
+	nfs "github.com/treeverse/go-nfs"
+	nfshelper "github.com/treeverse/go-nfs/helpers"
 )
 
 func main() {
@@ -89,7 +89,7 @@ which do not translate to this abstraction.
   In particular, the `Sys()` escape hatch is queried by this library, and
   if your file system populates a [`syscall.Stat_t`](https://golang.org/pkg/syscall/#Stat_t)
   concrete struct, the ownership specified in that object will be used.
-  You can also return a [`file.FileInfo`](https://github.com/willscott/go-nfs/blob/master/file/file.go#L5)
+  You can also return a [`file.FileInfo`](https://github.com/treeverse/go-nfs/blob/master/file/file.go#L5)
   which doesn't vary between platforms so may be easier to deal with.
 
 * Relevant RFCS:

--- a/conn.go
+++ b/conn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 
 	xdr2 "github.com/rasky/go-xdr/xdr2"
 	"github.com/willscott/go-nfs-client/nfs/rpc"
@@ -20,6 +21,10 @@ var (
 	ErrInputInvalid = errors.New("invalid input")
 	// ErrAlreadySent is returned when writing a header/status multiple times
 	ErrAlreadySent = errors.New("response already started")
+	// ErrAbortHandler is a sentinel panic value to abort a handler.
+	// Panicking with ErrAbortHandler still returns a system error to
+	// the client, but suppresses logging of a stack trace.
+	ErrAbortHandler = errors.New("nfs: abort handler")
 )
 
 // ResponseCode is a combination of accept_stat and reject_stat.
@@ -122,7 +127,19 @@ func (c *conn) handle(ctx context.Context, w *response) error {
 		}
 		return c.err(ctx, w, &ResponseCodeProcUnavailableError{})
 	}
-	appError := handler(ctx, w, c.Server.Handler)
+	var appError error
+	func() {
+		defer func() {
+			if r := recover(); r != nil && r != ErrAbortHandler {
+				const size = 64 << 10
+				buf := make([]byte, size)
+				buf = buf[:runtime.Stack(buf, false)]
+				Log.Errorf("panic in handler for %v: %v\n%s", w.req, r, buf)
+				appError = &ResponseCodeSystemError{}
+			}
+		}()
+		appError = handler(ctx, w, c.Server.Handler)
+	}()
 	if drainErr := w.drain(ctx); drainErr != nil {
 		return drainErr
 	}

--- a/example/helloworld/main.go
+++ b/example/helloworld/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
 
 	nfs "github.com/willscott/go-nfs"
 	nfshelper "github.com/willscott/go-nfs/helpers"

--- a/example/helloworld/main.go
+++ b/example/helloworld/main.go
@@ -7,8 +7,8 @@ import (
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
 
-	nfs "github.com/willscott/go-nfs"
-	nfshelper "github.com/willscott/go-nfs/helpers"
+	nfs "github.com/treeverse/go-nfs"
+	nfshelper "github.com/treeverse/go-nfs/helpers"
 )
 
 // ROFS is an intercepter for the filesystem indicating it should

--- a/example/osnfs/changeos.go
+++ b/example/osnfs/changeos.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 )
 
 // NewChangeOSFS wraps billy osfs to add the change interface

--- a/example/osnfs/main.go
+++ b/example/osnfs/main.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"os"
 
-	osfs "github.com/go-git/go-billy/v5/osfs"
+	osfs "github.com/go-git/go-billy/v6/osfs"
 	nfs "github.com/willscott/go-nfs"
 	nfshelper "github.com/willscott/go-nfs/helpers"
 )

--- a/example/osnfs/main.go
+++ b/example/osnfs/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	osfs "github.com/go-git/go-billy/v6/osfs"
-	nfs "github.com/willscott/go-nfs"
-	nfshelper "github.com/willscott/go-nfs/helpers"
+	nfs "github.com/treeverse/go-nfs"
+	nfshelper "github.com/treeverse/go-nfs/helpers"
 )
 
 func main() {

--- a/example/osview/main.go
+++ b/example/osview/main.go
@@ -1,36 +1,38 @@
 package main
 
-import (
-	"fmt"
-	"net"
-	"os"
+// osview requires memphis, which does not yet support go-billy/v6
 
-	"github.com/willscott/memphis"
+// import (
+// 	"fmt"
+// 	"net"
+// 	"os"
 
-	nfs "github.com/willscott/go-nfs"
-	nfshelper "github.com/willscott/go-nfs/helpers"
-)
+// 	"github.com/willscott/memphis"
 
-func main() {
-	port := ""
-	if len(os.Args) < 2 {
-		fmt.Printf("Usage: osview </path/to/folder> [port]\n")
-		return
-	} else if len(os.Args) == 3 {
-		port = os.Args[2]
-	}
+// 	nfs "github.com/willscott/go-nfs"
+// 	nfshelper "github.com/willscott/go-nfs/helpers"
+// )
 
-	listener, err := net.Listen("tcp", ":"+port)
-	if err != nil {
-		fmt.Printf("Failed to listen: %v\n", err)
-		return
-	}
-	fmt.Printf("Server running at %s\n", listener.Addr())
+// func main() {
+// 	port := ""
+// 	if len(os.Args) < 2 {
+// 		fmt.Printf("Usage: osview </path/to/folder> [port]\n")
+// 		return
+// 	} else if len(os.Args) == 3 {
+// 		port = os.Args[2]
+// 	}
 
-	fs := memphis.FromOS(os.Args[1])
-	bfs := fs.AsBillyFS(0, 0)
+// 	listener, err := net.Listen("tcp", ":"+port)
+// 	if err != nil {
+// 		fmt.Printf("Failed to listen: %v\n", err)
+// 		return
+// 	}
+// 	fmt.Printf("Server running at %s\n", listener.Addr())
 
-	handler := nfshelper.NewNullAuthHandler(bfs)
-	cacheHelper := nfshelper.NewCachingHandler(handler, 1024)
-	fmt.Printf("%v", nfs.Serve(listener, cacheHelper))
-}
+// 	fs := memphis.FromOS(os.Args[1])
+// 	bfs := fs.AsBillyFS(0, 0)
+
+// 	handler := nfshelper.NewNullAuthHandler(bfs)
+// 	cacheHelper := nfshelper.NewCachingHandler(handler, 1024)
+// 	fmt.Printf("%v", nfs.Serve(listener, cacheHelper))
+// }

--- a/example/osview/main.go
+++ b/example/osview/main.go
@@ -9,8 +9,8 @@ package main
 
 // 	"github.com/willscott/memphis"
 
-// 	nfs "github.com/willscott/go-nfs"
-// 	nfshelper "github.com/willscott/go-nfs/helpers"
+// 	nfs "github.com/treeverse/go-nfs"
+// 	nfshelper "github.com/treeverse/go-nfs/helpers"
 // )
 
 // func main() {

--- a/file.go
+++ b/file.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 	"github.com/willscott/go-nfs/file"
 )

--- a/file.go
+++ b/file.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v6"
+	"github.com/treeverse/go-nfs/file"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
-	"github.com/willscott/go-nfs/file"
 )
 
 // FileAttribute holds metadata about a filesystem object

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/willscott/go-nfs
+module github.com/treeverse/go-nfs
 
 go 1.19
 
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93
+	github.com/willscott/go-nfs v0.0.2
 	github.com/willscott/go-nfs-client v0.0.0-20240104095149-b44639837b00
 	github.com/willscott/memphis v0.0.0-20241203204924-a148a489d367
 	golang.org/x/sys v0.24.0
@@ -19,3 +20,5 @@ require (
 	github.com/polydawn/rio v0.0.0-20220823181337-7c31ad9831a4 // indirect
 	github.com/warpfork/go-errcat v0.0.0-20180917083543-335044ffc86e // indirect
 )
+
+replace github.com/willscott/go-nfs => .

--- a/go.mod
+++ b/go.mod
@@ -1,20 +1,19 @@
 module github.com/treeverse/go-nfs
 
-go 1.19
+go 1.23.0
 
 require (
-	github.com/go-git/go-billy/v5 v5.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93
-	github.com/willscott/go-nfs v0.0.2
+	github.com/willscott/go-nfs v0.0.3
 	github.com/willscott/go-nfs-client v0.0.0-20240104095149-b44639837b00
-	github.com/willscott/memphis v0.0.0-20241203204924-a148a489d367
-	golang.org/x/sys v0.24.0
+	golang.org/x/sys v0.34.0
 )
 
 require (
-	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
+	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/go-git/go-billy/v6 v6.0.0-20250711053805-c1f149aaab07 // indirect
 	github.com/polydawn/go-timeless-api v0.0.0-20220821201550-b93919e12c56 // indirect
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
 	github.com/polydawn/rio v0.0.0-20220823181337-7c31ad9831a4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93
-	github.com/willscott/go-nfs v0.0.3
+	github.com/treeverse/go-nfs v0.0.3
 	github.com/willscott/go-nfs-client v0.0.0-20240104095149-b44639837b00
 	golang.org/x/sys v0.34.0
 )
@@ -19,5 +19,3 @@ require (
 	github.com/polydawn/rio v0.0.0-20220823181337-7c31ad9831a4 // indirect
 	github.com/warpfork/go-errcat v0.0.0-20180917083543-335044ffc86e // indirect
 )
-
-replace github.com/willscott/go-nfs => .

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,10 @@
 github.com/cyphar/filepath-securejoin v0.2.5 h1:6iR5tXJ/e6tJZzzdMc1km3Sa7RRIVBKAK32O2s7AYfo=
 github.com/cyphar/filepath-securejoin v0.2.5/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
+github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/go-git/go-billy/v5 v5.6.0 h1:w2hPNtoehvJIxR00Vb4xX94qHQi/ApZfX+nBE2Cjio8=
-github.com/go-git/go-billy/v5 v5.6.0/go.mod h1:sFDq7xD3fn3E0GOwUSZqHo9lrkmx8xJhA0ZrfvjBRGM=
+github.com/go-git/go-billy/v6 v6.0.0-20250711053805-c1f149aaab07 h1:bCRyoFc25vETmjqzMCnrWMjYFWsHkOi9FcnkOZD5D6w=
+github.com/go-git/go-billy/v6 v6.0.0-20250711053805-c1f149aaab07/go.mod h1:Pa0/zeE0tC0GiZLFFtOYXOky9SgpNF+zkrj7aEJhBVg=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -37,6 +39,8 @@ golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0
 golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
+golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/handler.go
+++ b/handler.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 	"net"
 
-	billy "github.com/go-git/go-billy/v5"
+	billy "github.com/go-git/go-billy/v6"
 )
 
 // Handler represents the interface of the file system / vfs being exposed over NFS

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/willscott/go-nfs"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
 )

--- a/helpers/cachinghandler.go
+++ b/helpers/cachinghandler.go
@@ -6,7 +6,7 @@ import (
 	"io/fs"
 	"reflect"
 
-	"github.com/willscott/go-nfs"
+	"github.com/treeverse/go-nfs"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/google/uuid"

--- a/helpers/memfs/memfs.go
+++ b/helpers/memfs/memfs.go
@@ -1,4 +1,4 @@
-// Package memfs is a variant of "github.com/go-git/go-billy/v5/memfs" with
+// Package memfs is a variant of "github.com/go-git/go-billy/v6/memfs" with
 // stable mtimes for items.
 package memfs
 
@@ -13,9 +13,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-git/go-billy/v5"
-	"github.com/go-git/go-billy/v5/helper/chroot"
-	"github.com/go-git/go-billy/v5/util"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/chroot"
+	"github.com/go-git/go-billy/v6/util"
 )
 
 const separator = filepath.Separator

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -5,7 +5,7 @@ import (
 	"net"
 
 	"github.com/go-git/go-billy/v6"
-	"github.com/willscott/go-nfs"
+	"github.com/treeverse/go-nfs"
 )
 
 // NewNullAuthHandler creates a handler for the provided filesystem

--- a/helpers/nullauthhandler.go
+++ b/helpers/nullauthhandler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs"
 )
 

--- a/nfs_onaccess.go
+++ b/nfs_onaccess.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_oncommit.go
+++ b/nfs_oncommit.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_oncreate.go
+++ b/nfs_oncreate.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onfsinfo.go
+++ b/nfs_onfsinfo.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onfsstat.go
+++ b/nfs_onfsstat.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onlink.go
+++ b/nfs_onlink.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onlookup.go
+++ b/nfs_onlookup.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onmkdir.go
+++ b/nfs_onmkdir.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onmknod.go
+++ b/nfs_onmknod.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onread.go
+++ b/nfs_onread.go
@@ -49,6 +49,7 @@ func onRead(ctx context.Context, w *response, userHandle Handler) error {
 		}
 		return &NFSStatusError{NFSStatusAccess, err}
 	}
+	defer fh.Close()
 
 	resp := nfsReadResponse{}
 

--- a/nfs_onremove.go
+++ b/nfs_onremove.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onrename.go
+++ b/nfs_onrename.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onsetattr.go
+++ b/nfs_onsetattr.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_onsymlink.go
+++ b/nfs_onsymlink.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	"github.com/willscott/go-nfs-client/nfs/xdr"
 )
 

--- a/nfs_test.go
+++ b/nfs_test.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v6"
 	nfs "github.com/willscott/go-nfs"
 	"github.com/willscott/go-nfs/helpers"
 	"github.com/willscott/go-nfs/helpers/memfs"
@@ -230,8 +230,8 @@ func TestNFS(t *testing.T) {
 	as2.Sort()
 	bs2.Sort()
 	if !reflect.DeepEqual(as2, bs2) {
-		fmt.Printf("should be %v\n", as2)
-		fmt.Printf("actual be %v\n", bs2)
+		t.Logf("should be %v\n", as2)
+		t.Logf("actual be %v\n", bs2)
 		t.Fatal("nfs.ReadDir error")
 	}
 

--- a/nfs_test.go
+++ b/nfs_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
-	nfs "github.com/willscott/go-nfs"
-	"github.com/willscott/go-nfs/helpers"
-	"github.com/willscott/go-nfs/helpers/memfs"
+	nfs "github.com/treeverse/go-nfs"
+	"github.com/treeverse/go-nfs/helpers"
+	"github.com/treeverse/go-nfs/helpers/memfs"
 
 	nfsc "github.com/willscott/go-nfs-client/nfs"
 	rpc "github.com/willscott/go-nfs-client/nfs/rpc"


### PR DESCRIPTION
## Summary

Add panic recovery in `conn.handle()`, wrapping the handler dispatch call.
Same pattern as `net/http.Server`:

- Recover the panic
- Log the value and full stack trace via `Log.Errorf`
- Return `ResponseCodeSystemErr` to the NFS client for the failed request
- Keep the connection alive — the panic is isolated to the active request

Also adds `ErrAbortHandler`, a sentinel panic value that suppresses
logging (same as `net/http.ErrAbortHandler`).

## Motivation

When an NFS handler panics today, the `serve()` goroutine dies and the
connection drops. The panic message and stack trace are lost.

With this fix, the panic is caught, logged with a full stack trace,
and the NFS client gets a system error response instead of a dead connection.