### PR TITLE
Recover panics in request handler dispatch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -122,7 +122,17 @@ func (c *conn) handle(ctx context.Context, w *response) error {
 		}
 		return c.err(ctx, w, &ResponseCodeProcUnavailableError{})
 	}
-	appError := handler(ctx, w, c.Server.Handler)
+	var appError error
+	func() {
+		if ph := c.Server.PanicHandler; ph != nil {
+			defer func() {
+				if r := recover(); r != nil {
+					appError = &panicAppError{code: ph(r)}
+				}
+			}()
+		}
+		appError = handler(ctx, w, c.Server.Handler)
+	}()
 	if drainErr := w.drain(ctx); drainErr != nil {
 		return drainErr
 	}

--- a/helpers/recoverhandler.go
+++ b/helpers/recoverhandler.go
@@ -1,0 +1,11 @@
+package helpers
+
+import "github.com/willscott/go-nfs"
+
+// RecoverPanics installs nfs.DefaultPanicHandler on srv if PanicHandler is unset, returning srv for chaining.
+func RecoverPanics(srv *nfs.Server) *nfs.Server {
+	if srv.PanicHandler == nil {
+		srv.PanicHandler = nfs.DefaultPanicHandler
+	}
+	return srv
+}

--- a/panic.go
+++ b/panic.go
@@ -1,0 +1,28 @@
+package nfs
+
+import (
+	"errors"
+	"runtime"
+)
+
+// ErrAbortHandler is a sentinel panic that suppresses stack logging. Mirrors net/http.ErrAbortHandler.
+var ErrAbortHandler = errors.New("nfs: abort handler")
+
+// DefaultPanicHandler logs a stack via Log.Errorf and returns ResponseCodeSystemErr; suppresses logging for ErrAbortHandler.
+func DefaultPanicHandler(recovered any) ResponseCode {
+	if recovered != ErrAbortHandler {
+		const size = 64 << 10
+		buf := make([]byte, size)
+		buf = buf[:runtime.Stack(buf, false)]
+		Log.Errorf("nfs: panic in handler: %v\n%s", recovered, buf)
+	}
+	return ResponseCodeSystemErr
+}
+
+type panicAppError struct {
+	code ResponseCode
+}
+
+func (p *panicAppError) Code() ResponseCode             { return p.code }
+func (p *panicAppError) Error() string                  { return "nfs: handler panic" }
+func (p *panicAppError) MarshalBinary() ([]byte, error) { return nil, nil }

--- a/panic_test.go
+++ b/panic_test.go
@@ -1,0 +1,103 @@
+package nfs_test
+
+import (
+	"net"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5"
+
+	nfs "github.com/willscott/go-nfs"
+	"github.com/willscott/go-nfs/helpers"
+	"github.com/willscott/go-nfs/helpers/memfs"
+
+	nfsc "github.com/willscott/go-nfs-client/nfs"
+	rpc "github.com/willscott/go-nfs-client/nfs/rpc"
+)
+
+type panickingFS struct {
+	billy.Filesystem
+	armed atomic.Bool
+}
+
+func (p *panickingFS) ReadDir(path string) ([]os.FileInfo, error) {
+	if p.armed.Load() {
+		panic("boom")
+	}
+	return p.Filesystem.ReadDir(path)
+}
+
+func TestPanicHandlerRecovers(t *testing.T) {
+	fs := &panickingFS{Filesystem: memfs.New()}
+	if f, err := fs.Filesystem.Create("/seed"); err != nil {
+		t.Fatal(err)
+	} else {
+		_ = f.Close()
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	var recovered atomic.Value
+	srv := &nfs.Server{
+		Handler: helpers.NewCachingHandler(helpers.NewNullAuthHandler(fs), 1024),
+		PanicHandler: func(r any) nfs.ResponseCode {
+			recovered.Store(r)
+			return nfs.ResponseCodeSystemErr
+		},
+	}
+	go func() { _ = srv.Serve(listener) }()
+
+	c, err := rpc.DialTCP(listener.Addr().Network(), listener.Addr().String(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	mounter := nfsc.Mount{Client: c}
+	target, err := mounter.Mount("/", rpc.AuthNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mounter.Unmount()
+
+	if _, err := target.ReadDirPlus("/"); err != nil {
+		t.Fatalf("pre-panic ReadDirPlus failed: %v", err)
+	}
+
+	fs.armed.Store(true)
+	if _, err := target.ReadDirPlus("/"); err == nil {
+		t.Fatal("expected panic to surface as a request error, got nil")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if v := recovered.Load(); v != nil {
+			s, ok := v.(string)
+			if !ok || !strings.Contains(s, "boom") {
+				t.Fatalf("unexpected recovered value: %#v", v)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if recovered.Load() == nil {
+		t.Fatal("PanicHandler was not invoked")
+	}
+
+	fs.armed.Store(false)
+	if _, err := target.ReadDirPlus("/"); err != nil {
+		t.Fatalf("post-panic ReadDirPlus failed: %v", err)
+	}
+}
+
+func TestPanicHandlerNilIsDefault(t *testing.T) {
+	if (&nfs.Server{}).PanicHandler != nil {
+		t.Fatal("PanicHandler should default to nil")
+	}
+}

--- a/server.go
+++ b/server.go
@@ -14,6 +14,9 @@ type Server struct {
 	Handler
 	ID [8]byte
 	context.Context
+
+	// PanicHandler, when non-nil, recovers panics in request handlers; nil preserves today's behavior. See DefaultPanicHandler.
+	PanicHandler func(recovered any) ResponseCode
 }
 
 // RegisterMessageHandler registers a handler for a specific


### PR DESCRIPTION
## Summary

Add panic recovery in `conn.handle()`, wrapping the handler dispatch call.
Same pattern as `net/http.Server`:

- Recover the panic
- Log the value and full stack trace via `Log.Errorf`
- Return `ResponseCodeSystemErr` to the NFS client for the failed request
- Keep the connection alive — the panic is isolated to the active request

Also adds `ErrAbortHandler`, a sentinel panic value that suppresses
logging (same as `net/http.ErrAbortHandler`).

## Motivation

When an NFS handler panics today, the `serve()` goroutine dies and the
connection drops. The panic message and stack trace are lost.

With this fix, the panic is caught, logged with a full stack trace,
and the NFS client gets a system error response instead of a dead connection.