### PR TITLE
Implement MOUNTPROC_EXPORT (procedure 5)

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -15,6 +15,7 @@ func init() {
 	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcNull), onMountNull)
 	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcMount), onMount)
 	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcUmnt), onUMount)
+	_ = RegisterMessageHandler(mountServiceID, uint32(MountProcExport), onExport)
 }
 
 func onMountNull(ctx context.Context, w *response, userHandle Handler) error {
@@ -55,4 +56,62 @@ func onUMount(ctx context.Context, w *response, userHandle Handler) error {
 	}
 
 	return w.writeHeader(ResponseCodeSuccess)
+}
+
+// onExport implements MOUNTPROC_EXPORT (procedure 5) of the MOUNTv3 protocol,
+// returning the list of exports the server advertises. This is the call made
+// by `showmount -e` and many NFS storage-discovery probes (Hammerspace Anvil,
+// monitoring scripts, automounter discovery). Without it the dispatcher
+// writes no reply and the client times out.
+//
+// If userHandle implements ExportHandler, its Exports() method provides the
+// list; otherwise a single entry advertising "/" with no group restriction is
+// returned, which matches what a Handler effectively serves (the Mount RPC
+// hands out the same root handle regardless of the requested dirpath).
+//
+// See RFC 1813 section 5.2.5 for the wire format.
+func onExport(ctx context.Context, w *response, userHandle Handler) error {
+	var exports []Export
+	if eh, ok := userHandle.(ExportHandler); ok {
+		exports = eh.Exports()
+	}
+	if len(exports) == 0 {
+		exports = []Export{{Dir: "/"}}
+	}
+
+	if err := w.writeHeader(ResponseCodeSuccess); err != nil {
+		return err
+	}
+
+	writer := bytes.NewBuffer([]byte{})
+
+	for _, e := range exports {
+		// value-follows boolean for this export entry
+		if err := xdr.Write(writer, uint32(1)); err != nil {
+			return err
+		}
+		// ex_dir
+		if err := xdr.Write(writer, []byte(e.Dir)); err != nil {
+			return err
+		}
+		// ex_groups - linked list of group name strings
+		for _, g := range e.Groups {
+			if err := xdr.Write(writer, uint32(1)); err != nil {
+				return err
+			}
+			if err := xdr.Write(writer, []byte(g)); err != nil {
+				return err
+			}
+		}
+		// terminator for ex_groups
+		if err := xdr.Write(writer, uint32(0)); err != nil {
+			return err
+		}
+	}
+	// terminator for ex_next (end of exports list)
+	if err := xdr.Write(writer, uint32(0)); err != nil {
+		return err
+	}
+
+	return w.Write(writer.Bytes())
 }

--- a/mount_export_test.go
+++ b/mount_export_test.go
@@ -1,0 +1,181 @@
+package nfs_test
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	nfs "github.com/willscott/go-nfs"
+	"github.com/willscott/go-nfs/helpers"
+	"github.com/willscott/go-nfs/helpers/memfs"
+
+	nfsc "github.com/willscott/go-nfs-client/nfs"
+	rpc "github.com/willscott/go-nfs-client/nfs/rpc"
+	"github.com/willscott/go-nfs-client/nfs/xdr"
+)
+
+// readOpaque reads a variable-length opaque field and consumes the XDR
+// 4-byte alignment padding. The go-nfs-client xdr.ReadOpaque helper does not
+// consume the padding, which is fine for the last field of a body but breaks
+// multi-field reads.
+func readOpaque(r io.Reader) ([]byte, error) {
+	length, err := xdr.ReadUint32(r)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	if pad := (4 - int(length)%4) % 4; pad > 0 {
+		if _, err := io.CopyN(io.Discard, r, int64(pad)); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}
+
+// readExportList reads the XDR-encoded reply body of a MOUNTPROC_EXPORT call
+// and returns a flat list of (dirpath, groups). See RFC 1813 §5.2.5.
+func readExportList(t *testing.T, r io.Reader) []nfs.Export {
+	t.Helper()
+	var out []nfs.Export
+	for {
+		more, err := xdr.ReadUint32(r)
+		if err != nil {
+			t.Fatalf("read exports value-follows: %v", err)
+		}
+		if more == 0 {
+			return out
+		}
+		dir, err := readOpaque(r)
+		if err != nil {
+			t.Fatalf("read ex_dir: %v", err)
+		}
+		var groups []string
+		for {
+			more, err := xdr.ReadUint32(r)
+			if err != nil {
+				t.Fatalf("read group value-follows: %v", err)
+			}
+			if more == 0 {
+				break
+			}
+			name, err := readOpaque(r)
+			if err != nil {
+				t.Fatalf("read group name: %v", err)
+			}
+			groups = append(groups, string(name))
+		}
+		out = append(out, nfs.Export{Dir: string(dir), Groups: groups})
+	}
+}
+
+func callExport(t *testing.T, addr string) []nfs.Export {
+	t.Helper()
+	c, err := rpc.DialTCP("tcp", addr, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	res, err := c.Call(&rpc.Header{
+		Rpcvers: 2,
+		Prog:    nfsc.MountProg,
+		Vers:    nfsc.MountVers,
+		Proc:    nfsc.MountProc3Export,
+		Cred:    rpc.AuthNull,
+		Verf:    rpc.AuthNull,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return readExportList(t, res)
+}
+
+func startTestServer(t *testing.T, h nfs.Handler) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() { _ = nfs.Serve(listener, h) }()
+	return listener.Addr().String()
+}
+
+func TestMountExportDefault(t *testing.T) {
+	mem := memfs.New()
+	f, _ := mem.Create("/test")
+	_ = f.Close()
+
+	handler := helpers.NewNullAuthHandler(mem)
+	cached := helpers.NewCachingHandler(handler, 1024)
+
+	exports := callExport(t, startTestServer(t, cached))
+
+	if len(exports) != 1 {
+		t.Fatalf("want 1 export, got %d (%+v)", len(exports), exports)
+	}
+	if exports[0].Dir != "/" {
+		t.Errorf("want default dir \"/\", got %q", exports[0].Dir)
+	}
+	if len(exports[0].Groups) != 0 {
+		t.Errorf("want no group restriction, got %v", exports[0].Groups)
+	}
+}
+
+// exporterHandler wraps a Handler and implements the optional ExportHandler
+// interface so MOUNTPROC_EXPORT returns a caller-supplied list instead of
+// the default.
+type exporterHandler struct {
+	nfs.Handler
+	list []nfs.Export
+}
+
+func (e *exporterHandler) Exports() []nfs.Export { return e.list }
+
+func TestMountExportCustom(t *testing.T) {
+	mem := memfs.New()
+	f, _ := mem.Create("/test")
+	_ = f.Close()
+
+	base := helpers.NewCachingHandler(helpers.NewNullAuthHandler(mem), 1024)
+	wrapped := &exporterHandler{
+		Handler: base,
+		list: []nfs.Export{
+			{Dir: "/data", Groups: []string{"10.0.0.0/8", "192.168.0.0/16"}},
+			{Dir: "/scratch"},
+		},
+	}
+
+	got := callExport(t, startTestServer(t, wrapped))
+
+	want := []nfs.Export{
+		{Dir: "/data", Groups: []string{"10.0.0.0/8", "192.168.0.0/16"}},
+		{Dir: "/scratch"},
+	}
+	if !exportsEqual(got, want) {
+		t.Fatalf("export list mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func exportsEqual(a, b []nfs.Export) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Dir != b[i].Dir {
+			return false
+		}
+		if len(a[i].Groups) != len(b[i].Groups) {
+			return false
+		}
+		for j := range a[i].Groups {
+			if a[i].Groups[j] != b[i].Groups[j] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/mountinterface.go
+++ b/mountinterface.go
@@ -88,3 +88,19 @@ type MountResponse struct {
 	FileHandle
 	AuthFlavors []int
 }
+
+// Export represents one entry returned by MOUNTPROC_EXPORT. An empty Groups
+// slice means the export is accessible from anywhere (the wire encoding is a
+// nil groups list, which clients like `showmount -e` render as "(everyone)").
+type Export struct {
+	Dir    string
+	Groups []string
+}
+
+// ExportHandler is an optional interface a Handler may implement to provide a
+// custom list of exports for MOUNTPROC_EXPORT. Handlers that do not implement
+// it get a default response of a single entry advertising "/" with no group
+// restriction, which matches what the Mount RPC effectively serves.
+type ExportHandler interface {
+	Exports() []Export
+}


### PR DESCRIPTION
## Summary

Adds a handler for `MOUNTPROC_EXPORT` (procedure 5 of the MOUNTv3 protocol). Currently the dispatcher registers handlers for `NULL` (0), `MNT` (1), and `UMNT` (3) only — `EXPORT` is silently unhandled, so when a client invokes it the request is parsed but no reply is written, and the client hangs until it times out.

## Motivation

`MOUNTPROC_EXPORT` is the call `showmount -e` makes, and it's commonly used as a "find available exports" probe by NFS storage discovery and inventory tools (Hammerspace Anvil's "create storage system" flow, monitoring/inventory scripts, automounter discovery, certain backup agents, etc.). With this missing, those tools fail with vague errors like *"Failed to read NFS exports from node `<host>`. Is NFS running?"* — even though `MNT` works and the server is responding to NFS requests normally.

The minimum repro is just:

```
showmount -e <host running a go-nfs server>
```

Currently times out; after this PR it returns the export list.

## What this PR does

1. Adds `onExport` in `mount.go` and registers it for `MountProcExport`. The handler encodes the response body per [RFC 1813 §5.2.5](https://datatracker.ietf.org/doc/html/rfc1813#section-5.2.5):

   ```
   typedef struct exportnode *exports;
   struct exportnode { dirpath ex_dir; groups ex_groups; exports ex_next; };
   ```

2. Adds a small public surface in `mountinterface.go`:

   ```go
   type Export struct {
       Dir    string
       Groups []string
   }

   type ExportHandler interface {
       Exports() []Export
   }
   ```

   - `ExportHandler` is **optional**: handlers that don't implement it get a sensible default — a single entry advertising `/` with no group restriction. This matches what `onMount` effectively serves (`onMount` ignores the requested `dirpath` and always returns the same root handle).
   - Handlers that want a richer or scoped list (multiple exports, per-export ACL hints, etc.) can implement `ExportHandler` without breaking existing implementers.

3. Adds `mount_export_test.go` with two tests:
   - `TestMountExportDefault` — handler does **not** implement `ExportHandler`; verifies the default `/` entry.
   - `TestMountExportCustom` — handler returns a multi-entry list with group restrictions; verifies the wire encoding by manually XDR-decoding the response.

## Design notes

- **Default vs. interface**: I considered hardcoding `/` and skipping the interface, but discovery tools that auto-import exports want to see meaningful names, and there's no breaking-change cost to providing the hook now. Existing handlers compile unchanged.
- **Group format**: `RFC 1813` defines `ex_groups` as a linked list of `name` strings, and is intentionally vague about what's inside the string. Common conventions are CIDR (`10.0.0.0/8`), single host, netgroup name, `gss/krb5*`, or `*` for everyone. This PR passes through whatever the caller puts in `Export.Groups` without interpretation, which is consistent with how `rpc.mountd` treats `/etc/exports`.
- **Wire helper**: the test contains a small `readOpaque` helper that consumes XDR alignment padding. `go-nfs-client/nfs/xdr.ReadOpaque` does not skip padding, which is fine when an opaque is the last field of a body (as it is for `MNT`) but breaks when reading a multi-field response. Worth noting separately — possibly a follow-up bug in go-nfs-client. I've kept the helper in the test file to avoid expanding the patch scope.

## Verification

```
$ go test ./...
ok  	github.com/willscott/go-nfs	0.492s
ok  	github.com/willscott/go-nfs/helpers	0.336s
```

Manual end-to-end check against a real client (rclone serve nfs built with this patch via `go mod replace`):

```
# before
$ showmount -e <host>
rpc mount export: RPC: Timed out

# after
$ showmount -e <host>
Export list for <host>:
/ (everyone)
```

## Compatibility

- No changes to any existing function signature or interface.
- `Handler` interface unchanged (`ExportHandler` is additive and optional).
- Existing tests (`TestNFS`, `TestReadEOF`) pass unchanged.
